### PR TITLE
fix(specs): correct Bun preload path in smoke-install

### DIFF
--- a/specs/smoke-install.sh
+++ b/specs/smoke-install.sh
@@ -147,7 +147,7 @@ run_smoke_tests() {
     \""
 
   smoke_test "bun test store" \
-    "export PATH=$BUN_BIN:\$PATH; cd /opt/kindx && bun test --preload ./engine/preloader.ts --timeout 30000 specs/store.test.ts 2>&1 | tail -10"
+    "set -o pipefail; export PATH=$BUN_BIN:\$PATH; cd /opt/kindx && bun test --preload ./engine/preloader.ts --timeout 30000 specs/store.test.ts 2>&1 | tail -10"
 
   # ------------------------------------------------------------------
   echo ""


### PR DESCRIPTION
## Summary
- fix `specs/smoke-install.sh` Bun smoke test preload path
- replace missing `./engine/test-preload.ts` with existing `./engine/preloader.ts`
- keep preload file naming/layout unchanged

Closes #49

## Validation
- `npm run build` passed
- `bun test --preload ./engine/preloader.ts --timeout 30000 specs/store.test.ts` resolves preload path (suite still has pre-existing sqlite-vec env-dependent failures)
- smoke command in `specs/smoke-install.sh` now points to `engine/preloader.ts`
- `specs/smoke-install.sh --build` builds image
- container Bun command executed with corrected preload path and no preload-not-found error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved smoke tests: enabled stricter shell error handling and updated the test preloader used by Bun-installed smoke tests to improve reliability and failure detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->