### PR TITLE
feat(engine): harden sqlite concurrent index access with busy timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,9 @@ kindx --skill                # Print the packaged skill markdown
 kindx --version              # Print the installed CLI version
 ```
 
+KINDX opens SQLite indexes with `journal_mode=WAL` and `busy_timeout=5000`, so background writers
+(for example `kindx watch`) and MCP readers can run concurrently with fewer lock conflicts.
+
 Collection subcommands:
 
 ```bash

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -631,6 +631,7 @@ function initializeDatabase(db: Database): void {
     _sqliteVecAvailable = false;
   }
   db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
   db.exec("PRAGMA foreign_keys = ON");
 
   // Drop legacy tables that are now managed in YAML

--- a/specs/mcp.test.ts
+++ b/specs/mcp.test.ts
@@ -35,6 +35,7 @@ afterAll(async () => {
 function initTestDatabase(db: Database): void {
   loadSqliteVec(db);
   db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
 
   // Content-addressable storage - the source of truth for document content
   db.exec(`
@@ -257,6 +258,13 @@ describe("MCP Server", () => {
   // ===========================================================================
   // Tool: qmd_search (BM25)
   // ===========================================================================
+
+  test("test DB setup enables SQLite concurrency pragmas", () => {
+    const journal = testDb.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
+    const timeout = testDb.prepare("PRAGMA busy_timeout").get() as { timeout: number };
+    expect(journal.journal_mode).toBe("wal");
+    expect(timeout.timeout).toBe(5000);
+  });
 
   describe("searchFTS (BM25 keyword search)", () => {
     test("returns results for matching query", () => {

--- a/specs/store.test.ts
+++ b/specs/store.test.ts
@@ -462,6 +462,13 @@ describe("Store Creation", () => {
     await cleanupTestDb(store);
   });
 
+  test("createStore sets SQLite busy timeout", async () => {
+    const store = await createTestStore();
+    const result = store.db.prepare("PRAGMA busy_timeout").get() as { timeout: number };
+    expect(result.timeout).toBe(5000);
+    await cleanupTestDb(store);
+  });
+
   test("verifySqliteVecLoaded throws when sqlite-vec is not loaded", () => {
     const db = openDatabase(":memory:");
     try {


### PR DESCRIPTION
## Summary
- enforce SQLite concurrency pragmas on store-backed index opens
- keep journal_mode=WAL and add busy_timeout=5000 in DB initialization
- align MCP test DB initialization with the same pragma set
- add regression assertions for WAL + busy timeout behavior
- document watcher/MCP concurrent read-write guarantee in README

## Scope
- Implements Option 4 from #28 via #63 only
- No MCP multi-index routing or auto index detection changes

Closes #63
Refs #28

## Validation
- npm run build
- npx vitest run specs/store.test.ts --reporter=verbose
- npx vitest run specs/mcp.test.ts --reporter=verbose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SQLite concurrent database access with enhanced timeout handling, enabling background writers and multiple readers to operate more efficiently with fewer lock conflicts.

* **Documentation**
  * Added guidance on SQLite configuration optimizations for concurrent database access scenarios.

* **Tests**
  * Added test coverage validating SQLite timeout and journal mode configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->