### PR TITLE
feat(engine): implement Phase 1 corrective feedback loop (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ kindx multi-get "journals/2025-05*.md"
 # Scoped Contextual Retrieval within a collection
 kindx search "API" -c notes
 
+# Corrective feedback (Phase 1)
+kindx feedback --irrelevant --query "deploy k8s" --chunk "#abc123:2"
+kindx feedback --relevant --query "deploy k8s" --chunk "#abc123:2"
+kindx feedback list --query "deploy"
+
 # Export full match set for agent pipeline
 kindx search "API" --all --files --min-score 0.3
 
@@ -138,6 +143,7 @@ KINDX exposes a Model Context Protocol (MCP) server for tool-call integration wi
 - `kindx_get` — Neural Extraction by path or docid (with fuzzy matching fallback)
 - `kindx_multi_get` — Bulk Neural Extraction by glob pattern, list, or docids
 - `kindx_status` — Index health and collection inventory
+- `kindx_feedback` — Store relevance feedback (`relevant` / `irrelevant`) for query+chunk pairs
 
 **Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -2505,7 +2505,6 @@ function parseCLI() {
       // Feedback options
       query: { type: "string" },
       chunk: { type: "string" },
-      session: { type: "string" },
       relevant: { type: "boolean" },
       irrelevant: { type: "boolean" },
       // MCP HTTP transport options
@@ -2735,11 +2734,6 @@ function resolveFeedbackChunkToHashSeq(db: Database, chunkRaw: string): string {
     return `${hashSeqMatch[1]}_${hashSeqMatch[2]}`;
   }
 
-  const hashWithSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]{7,})(?::(\d+))?$/i);
-  if (hashWithSeqMatch) {
-    return `${hashWithSeqMatch[1]}_${hashWithSeqMatch[2] ?? "0"}`;
-  }
-
   const docidWithSeqMatch = chunk.match(/^([a-z0-9]{4,8})(?::(\d+))?$/i);
   if (docidWithSeqMatch) {
     const doc = findDocumentByDocid(db, docidWithSeqMatch[1]);
@@ -2747,6 +2741,11 @@ function resolveFeedbackChunkToHashSeq(db: Database, chunkRaw: string): string {
       throw new Error(`Unknown docid: #${docidWithSeqMatch[1]}`);
     }
     return `${doc.hash}_${docidWithSeqMatch[2] ?? "0"}`;
+  }
+
+  const hashWithSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]{8,})(?::(\d+))?$/i);
+  if (hashWithSeqMatch) {
+    return `${hashWithSeqMatch[1]}_${hashWithSeqMatch[2] ?? "0"}`;
   }
 
   throw new Error("Invalid chunk format. Use #docid[:seq], full-hash[:seq], or hash_seq.");
@@ -2873,8 +2872,7 @@ if (isMain) {
           for (const row of rows) {
             const signal = row.signal < 0 ? "irrelevant" : "relevant";
             const when = new Date(row.created * 1000).toISOString();
-            const session = row.session ? ` session=${row.session}` : "";
-            console.log(`- [${signal}] query="${row.query}" chunk="${row.hashSeq}" at ${when}${session}`);
+            console.log(`- [${signal}] query="${row.query}" chunk="${row.hashSeq}" at ${when}`);
           }
         }
         break;
@@ -2883,15 +2881,14 @@ if (isMain) {
       const relevant = !!cli.values.relevant;
       const irrelevant = !!cli.values.irrelevant;
       if (relevant === irrelevant) {
-        console.error("Usage: kindx feedback --relevant|--irrelevant --query <text> --chunk <id> [--session <id>]");
+        console.error("Usage: kindx feedback --relevant|--irrelevant --query <text> --chunk <id>");
         process.exit(1);
       }
 
       const queryText = ((cli.values.query as string | undefined) ?? "").trim();
       const chunkArg = ((cli.values.chunk as string | undefined) ?? "").trim();
-      const session = ((cli.values.session as string | undefined) ?? "").trim() || null;
       if (!queryText || !chunkArg) {
-        console.error("Usage: kindx feedback --relevant|--irrelevant --query <text> --chunk <id> [--session <id>]");
+        console.error("Usage: kindx feedback --relevant|--irrelevant --query <text> --chunk <id>");
         process.exit(1);
       }
 
@@ -2904,10 +2901,10 @@ if (isMain) {
       }
 
       const signal: -1 | 1 = relevant ? 1 : -1;
-      store.insertFeedback(queryText, hashSeq, signal, session);
+      store.insertFeedback(queryText, hashSeq, signal);
       const signalText = signal > 0 ? "relevant" : "irrelevant";
       if (cli.opts.format === "json") {
-        console.log(JSON.stringify({ stored: true, query: queryText, chunk: hashSeq, signal: signalText, session }, null, 2));
+        console.log(JSON.stringify({ stored: true, query: queryText, chunk: hashSeq, signal: signalText }, null, 2));
       } else {
         console.log(`${c.green}✓${c.reset} Stored ${signalText} feedback for ${hashSeq}`);
       }

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -2502,6 +2502,12 @@ function parseCLI() {
       "line-numbers": { type: "boolean" },  // add line numbers to output
       // Query options
       "candidate-limit": { type: "string", short: "C" },
+      // Feedback options
+      query: { type: "string" },
+      chunk: { type: "string" },
+      session: { type: "string" },
+      relevant: { type: "boolean" },
+      irrelevant: { type: "boolean" },
       // MCP HTTP transport options
       http: { type: "boolean" },
       daemon: { type: "boolean" },
@@ -2608,6 +2614,7 @@ function showHelp(): void {
   console.log("  kindx vsearch <query>           - Vector similarity only");
   console.log("  kindx get <file>[:line] [--from <line>] [-l N] [--line-numbers]  - Show a single document from specific line, optional line slice");
   console.log("  kindx multi-get <pattern>       - Batch fetch via glob or comma-separated list");
+  console.log("  kindx feedback --irrelevant ... - Store corrective relevance feedback for retrieval");
   console.log("  kindx mcp                       - Start the MCP server (stdio transport for AI agents)");
   console.log("  kindx pull [--refresh]          - Download/check the default local GGUF models");
   console.log("  kindx skill install             - Copy the KINDX skill to ~/.claude/commands/ for one-command setup");
@@ -2631,6 +2638,11 @@ function showHelp(): void {
   console.log("  kindx update [--pull]           - Re-index collections (optionally git pull first)");
   console.log("  kindx embed [-f]                - Generate/refresh vector embeddings");
   console.log("  kindx cleanup                   - Clear caches, vacuum DB");
+  console.log("");
+  console.log("Corrective feedback:");
+  console.log("  kindx feedback --irrelevant --query \"deploy k8s\" --chunk \"#abc123:2\"");
+  console.log("  kindx feedback --relevant --query \"deploy k8s\" --chunk \"#def456:0\"");
+  console.log("  kindx feedback list --query \"deploy\"");
   console.log("");
   console.log("Query syntax (kindx query):");
   console.log("  KINDX queries are either a single expand query (no prefix) or a multi-line");
@@ -2684,6 +2696,9 @@ function showHelp(): void {
   console.log("  --explain                  - Include retrieval score traces (query --json/CLI)");
   console.log("  --files | --json | --csv | --md | --xml  - Output format");
   console.log("  -c, --collection <name>    - Filter by one or more collections");
+  console.log("  --query <text>             - Feedback query text (for kindx feedback)");
+  console.log("  --chunk <id>               - Feedback chunk id (#docid[:seq], hash[:seq], or hash_seq)");
+  console.log("  --relevant/--irrelevant    - Feedback signal for kindx feedback");
   console.log("");
   console.log("Multi-get options:");
   console.log("  -l <num>                   - Maximum lines per file");
@@ -2707,6 +2722,34 @@ async function showVersion(): Promise<void> {
 
   const versionStr = commit ? `${pkg.version} (${commit})` : pkg.version;
   console.log(`kindx ${versionStr}`);
+}
+
+function resolveFeedbackChunkToHashSeq(db: Database, chunkRaw: string): string {
+  const chunk = chunkRaw.trim().replace(/^#/, "");
+  if (!chunk) {
+    throw new Error("chunk is required");
+  }
+
+  const hashSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]*)_(\d+)$/i);
+  if (hashSeqMatch) {
+    return `${hashSeqMatch[1]}_${hashSeqMatch[2]}`;
+  }
+
+  const hashWithSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]{7,})(?::(\d+))?$/i);
+  if (hashWithSeqMatch) {
+    return `${hashWithSeqMatch[1]}_${hashWithSeqMatch[2] ?? "0"}`;
+  }
+
+  const docidWithSeqMatch = chunk.match(/^([a-z0-9]{4,8})(?::(\d+))?$/i);
+  if (docidWithSeqMatch) {
+    const doc = findDocumentByDocid(db, docidWithSeqMatch[1]);
+    if (!doc) {
+      throw new Error(`Unknown docid: #${docidWithSeqMatch[1]}`);
+    }
+    return `${doc.hash}_${docidWithSeqMatch[2] ?? "0"}`;
+  }
+
+  throw new Error("Invalid chunk format. Use #docid[:seq], full-hash[:seq], or hash_seq.");
 }
 
 // Main CLI - only run if this is the main module
@@ -2808,6 +2851,65 @@ if (isMain) {
           console.error(`Unknown subcommand: ${subcommand}`);
           console.error("Available: add, list, rm");
           process.exit(1);
+      }
+      break;
+    }
+
+    case "feedback": {
+      const subcommand = cli.args[0];
+      const db = getDb();
+      const store = getStore();
+
+      if (subcommand === "list") {
+        const queryFilter = ((cli.values.query as string | undefined) ?? cli.args.slice(1).join(" ")).trim();
+        const rows = store.listFeedback(queryFilter || undefined);
+
+        if (cli.opts.format === "json") {
+          console.log(JSON.stringify({ count: rows.length, feedback: rows }, null, 2));
+        } else if (rows.length === 0) {
+          console.log("No feedback records found.");
+        } else {
+          console.log(`${c.bold}Feedback records${c.reset} (${rows.length})`);
+          for (const row of rows) {
+            const signal = row.signal < 0 ? "irrelevant" : "relevant";
+            const when = new Date(row.created * 1000).toISOString();
+            const session = row.session ? ` session=${row.session}` : "";
+            console.log(`- [${signal}] query="${row.query}" chunk="${row.hashSeq}" at ${when}${session}`);
+          }
+        }
+        break;
+      }
+
+      const relevant = !!cli.values.relevant;
+      const irrelevant = !!cli.values.irrelevant;
+      if (relevant === irrelevant) {
+        console.error("Usage: kindx feedback --relevant|--irrelevant --query <text> --chunk <id> [--session <id>]");
+        process.exit(1);
+      }
+
+      const queryText = ((cli.values.query as string | undefined) ?? "").trim();
+      const chunkArg = ((cli.values.chunk as string | undefined) ?? "").trim();
+      const session = ((cli.values.session as string | undefined) ?? "").trim() || null;
+      if (!queryText || !chunkArg) {
+        console.error("Usage: kindx feedback --relevant|--irrelevant --query <text> --chunk <id> [--session <id>]");
+        process.exit(1);
+      }
+
+      let hashSeq: string;
+      try {
+        hashSeq = resolveFeedbackChunkToHashSeq(db, chunkArg);
+      } catch (err) {
+        console.error(String(err instanceof Error ? err.message : err));
+        process.exit(1);
+      }
+
+      const signal: -1 | 1 = relevant ? 1 : -1;
+      store.insertFeedback(queryText, hashSeq, signal, session);
+      const signalText = signal > 0 ? "relevant" : "irrelevant";
+      if (cli.opts.format === "json") {
+        console.log(JSON.stringify({ stored: true, query: queryText, chunk: hashSeq, signal: signalText, session }, null, 2));
+      } else {
+        console.log(`${c.green}✓${c.reset} Stored ${signalText} feedback for ${hashSeq}`);
       }
       break;
     }

--- a/engine/protocol.ts
+++ b/engine/protocol.ts
@@ -81,6 +81,26 @@ function formatSearchSummary(results: SearchResultItem[], query: string): string
   return lines.join('\n');
 }
 
+function resolveChunkToHashSeq(store: Store, rawChunkId: string): string {
+  const chunk = rawChunkId.trim().replace(/^#/, "");
+  if (!chunk) throw new Error("chunkId is required");
+
+  const hashSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]*)_(\d+)$/i);
+  if (hashSeqMatch) return `${hashSeqMatch[1]}_${hashSeqMatch[2]}`;
+
+  const hashWithSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]{7,})(?::(\d+))?$/i);
+  if (hashWithSeqMatch) return `${hashWithSeqMatch[1]}_${hashWithSeqMatch[2] ?? "0"}`;
+
+  const docidWithSeqMatch = chunk.match(/^([a-z0-9]{4,8})(?::(\d+))?$/i);
+  if (docidWithSeqMatch) {
+    const doc = store.findDocumentByDocid(docidWithSeqMatch[1]);
+    if (!doc) throw new Error(`unknown docid: #${docidWithSeqMatch[1]}`);
+    return `${doc.hash}_${docidWithSeqMatch[2] ?? "0"}`;
+  }
+
+  throw new Error("invalid chunkId format. Use #docid[:seq], full-hash[:seq], or hash_seq.");
+}
+
 // =============================================================================
 // MCP Server
 // =============================================================================
@@ -353,6 +373,56 @@ Intent-aware lex (C++ performance, not sports):
         content: [{ type: "text", text: formatSearchSummary(filtered, primaryQuery) }],
         structuredContent: { results: filtered },
       };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: kindx_feedback (Corrective feedback loop)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "kindx_feedback",
+    {
+      title: "Corrective Feedback",
+      description: "Store retrieval feedback for a query+chunk pair. Use this when a retrieved chunk was relevant or irrelevant.",
+      annotations: { readOnlyHint: false, openWorldHint: false },
+      inputSchema: {
+        query: z.string().describe("Original user query text"),
+        chunkId: z.string().describe("Chunk id (#docid[:seq], full-hash[:seq], or hash_seq)"),
+        signal: z.enum(["relevant", "irrelevant"]).describe("Feedback signal"),
+        session: z.string().optional().describe("Optional session identifier"),
+      },
+    },
+    async ({ query, chunkId, signal, session }: any) => {
+      const normalizedQuery = String(query || "").trim();
+      const normalizedChunk = String(chunkId || "").trim();
+      if (!normalizedQuery || !normalizedChunk) {
+        return {
+          content: [{ type: "text", text: "query and chunkId are required" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const hashSeq = resolveChunkToHashSeq(store, normalizedChunk);
+        const numericSignal: -1 | 1 = signal === "relevant" ? 1 : -1;
+        store.insertFeedback(normalizedQuery, hashSeq, numericSignal, session ?? null);
+        return {
+          content: [{ type: "text", text: `stored ${signal} feedback for ${hashSeq}` }],
+          structuredContent: {
+            stored: true,
+            query: normalizedQuery,
+            chunkId: hashSeq,
+            signal,
+            ...(session ? { session } : {}),
+          },
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: err instanceof Error ? err.message : "feedback storage failed" }],
+          isError: true,
+        };
+      }
     }
   );
 

--- a/engine/protocol.ts
+++ b/engine/protocol.ts
@@ -88,15 +88,15 @@ function resolveChunkToHashSeq(store: Store, rawChunkId: string): string {
   const hashSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]*)_(\d+)$/i);
   if (hashSeqMatch) return `${hashSeqMatch[1]}_${hashSeqMatch[2]}`;
 
-  const hashWithSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]{7,})(?::(\d+))?$/i);
-  if (hashWithSeqMatch) return `${hashWithSeqMatch[1]}_${hashWithSeqMatch[2] ?? "0"}`;
-
   const docidWithSeqMatch = chunk.match(/^([a-z0-9]{4,8})(?::(\d+))?$/i);
   if (docidWithSeqMatch) {
     const doc = store.findDocumentByDocid(docidWithSeqMatch[1]);
     if (!doc) throw new Error(`unknown docid: #${docidWithSeqMatch[1]}`);
     return `${doc.hash}_${docidWithSeqMatch[2] ?? "0"}`;
   }
+
+  const hashWithSeqMatch = chunk.match(/^([a-z0-9][a-z0-9._-]{8,})(?::(\d+))?$/i);
+  if (hashWithSeqMatch) return `${hashWithSeqMatch[1]}_${hashWithSeqMatch[2] ?? "0"}`;
 
   throw new Error("invalid chunkId format. Use #docid[:seq], full-hash[:seq], or hash_seq.");
 }
@@ -390,10 +390,9 @@ Intent-aware lex (C++ performance, not sports):
         query: z.string().describe("Original user query text"),
         chunkId: z.string().describe("Chunk id (#docid[:seq], full-hash[:seq], or hash_seq)"),
         signal: z.enum(["relevant", "irrelevant"]).describe("Feedback signal"),
-        session: z.string().optional().describe("Optional session identifier"),
       },
     },
-    async ({ query, chunkId, signal, session }: any) => {
+    async ({ query, chunkId, signal }: any) => {
       const normalizedQuery = String(query || "").trim();
       const normalizedChunk = String(chunkId || "").trim();
       if (!normalizedQuery || !normalizedChunk) {
@@ -406,7 +405,7 @@ Intent-aware lex (C++ performance, not sports):
       try {
         const hashSeq = resolveChunkToHashSeq(store, normalizedChunk);
         const numericSignal: -1 | 1 = signal === "relevant" ? 1 : -1;
-        store.insertFeedback(normalizedQuery, hashSeq, numericSignal, session ?? null);
+        store.insertFeedback(normalizedQuery, hashSeq, numericSignal);
         return {
           content: [{ type: "text", text: `stored ${signal} feedback for ${hashSeq}` }],
           structuredContent: {
@@ -414,7 +413,6 @@ Intent-aware lex (C++ performance, not sports):
             query: normalizedQuery,
             chunkId: hashSeq,
             signal,
-            ...(session ? { session } : {}),
           },
         };
       } catch (err) {

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -695,6 +695,19 @@ function initializeDatabase(db: Database): void {
     )
   `);
 
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS feedback (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      query TEXT NOT NULL,
+      hash_seq TEXT NOT NULL,
+      signal INTEGER NOT NULL,
+      created INTEGER NOT NULL DEFAULT (unixepoch()),
+      session TEXT,
+      UNIQUE(query, hash_seq)
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_feedback_query ON feedback(query)`);
+
   // FTS - index filepath (collection/path), title, and content
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
@@ -838,6 +851,10 @@ export type Store = {
   clearAllEmbeddings: () => void;
   insertEmbedding: (hash: string, seq: number, pos: number, embedding: Float32Array, model: string, embeddedAt: string) => void;
 
+  // Corrective feedback
+  insertFeedback: (query: string, hashSeq: string, signal: -1 | 1, session?: string | null) => void;
+  listFeedback: (query?: string) => FeedbackRecord[];
+
   // Watcher integrations
   indexSingleFile: (collectionName: string, relativePath: string, absolutePath: string) => Promise<"embedded" | "unchanged" | "failed">;
   unlinkSingleFile: (collectionName: string, relativePath: string) => Promise<boolean>;
@@ -928,6 +945,8 @@ export function createStore(dbPath?: string): Store {
     getHashesForEmbedding: () => getHashesForEmbedding(db),
     clearAllEmbeddings: () => clearAllEmbeddings(db),
     insertEmbedding: (hash: string, seq: number, pos: number, embedding: Float32Array, model: string, embeddedAt: string) => insertEmbedding(db, hash, seq, pos, embedding, model, embeddedAt),
+    insertFeedback: (query: string, hashSeq: string, signal: -1 | 1, session?: string | null) => insertFeedback(db, query, hashSeq, signal, session),
+    listFeedback: (query?: string) => listFeedback(db, query),
   };
 }
 
@@ -1048,6 +1067,7 @@ export type RankedResult = {
   title: string;
   body: string;
   score: number;
+  hash?: string;
 };
 
 export type RRFContributionTrace = {
@@ -1083,6 +1103,16 @@ export type HybridQueryExplain = {
   };
   rerankScore: number;
   blendedScore: number;
+  feedbackPenalty?: number;
+};
+
+export type FeedbackRecord = {
+  id: number;
+  query: string;
+  hashSeq: string;
+  signal: -1 | 1;
+  created: number;
+  session: string | null;
 };
 
 /**
@@ -2470,6 +2500,84 @@ export async function rerank(query: string, documents: { file: string; text: str
     .sort((a, b) => b.score - a.score);
 }
 
+function normalizeFeedbackQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+function normalizeHashSeq(hashSeq: string): string {
+  return hashSeq.trim().replace(/^#/, "");
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function insertFeedback(
+  db: Database,
+  query: string,
+  hashSeq: string,
+  signal: -1 | 1,
+  session?: string | null,
+): void {
+  const normalizedQuery = normalizeFeedbackQuery(query);
+  const normalizedHashSeq = normalizeHashSeq(hashSeq);
+  if (!normalizedQuery) throw new Error("query is required");
+  if (!normalizedHashSeq) throw new Error("hash_seq is required");
+  if (signal !== -1 && signal !== 1) throw new Error("signal must be -1 or 1");
+
+  db.prepare(`
+    INSERT INTO feedback (query, hash_seq, signal, session, created)
+    VALUES (?, ?, ?, ?, unixepoch())
+    ON CONFLICT(query, hash_seq)
+    DO UPDATE SET signal = excluded.signal, session = excluded.session, created = unixepoch()
+  `).run(normalizedQuery, normalizedHashSeq, signal, session ?? null);
+}
+
+export function listFeedback(db: Database, query?: string): FeedbackRecord[] {
+  const normalized = query ? normalizeFeedbackQuery(query) : "";
+  const rows = normalized
+    ? db.prepare(`
+        SELECT id, query, hash_seq, signal, created, session
+        FROM feedback
+        WHERE query LIKE ?
+        ORDER BY created DESC, id DESC
+      `).all(`%${normalized}%`)
+    : db.prepare(`
+        SELECT id, query, hash_seq, signal, created, session
+        FROM feedback
+        ORDER BY created DESC, id DESC
+      `).all();
+
+  return (rows as any[]).map((row) => ({
+    id: Number(row.id),
+    query: String(row.query),
+    hashSeq: String(row.hash_seq),
+    signal: Number(row.signal) < 0 ? -1 : 1,
+    created: Number(row.created),
+    session: row.session ?? null,
+  }));
+}
+
+export function getFeedbackPenalty(db: Database, query: string, hash?: string): number {
+  const normalizedQuery = normalizeFeedbackQuery(query);
+  if (!normalizedQuery || !hash) return 0;
+  const hashPrefix = `${hash}_%`;
+
+  const rows = db.prepare(`
+    SELECT signal
+    FROM feedback
+    WHERE query = ? AND hash_seq LIKE ?
+  `).all(normalizedQuery, hashPrefix) as { signal: number }[];
+
+  if (rows.length === 0) return 0;
+
+  let penalty = 0;
+  for (const row of rows) {
+    penalty += row.signal < 0 ? -0.15 : 0.05;
+  }
+  return clamp(penalty, -0.30, 0.10);
+}
+
 // =============================================================================
 // Reciprocal Rank Fusion
 // =============================================================================
@@ -3140,7 +3248,7 @@ export async function hybridQuery(
     for (const r of initialFts) docidMap.set(r.filepath, r.docid);
     rankedLists.push(initialFts.map(r => ({
       file: r.filepath, displayPath: r.displayPath,
-      title: r.title, body: r.body || "", score: r.score,
+      title: r.title, body: r.body || "", score: r.score, hash: r.hash,
     })));
     rankedListMeta.push({ source: "fts", queryType: "original", query });
   }
@@ -3159,7 +3267,7 @@ export async function hybridQuery(
         for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
         rankedLists.push(ftsResults.map(r => ({
           file: r.filepath, displayPath: r.displayPath,
-          title: r.title, body: r.body || "", score: r.score,
+          title: r.title, body: r.body || "", score: r.score, hash: r.hash,
         })));
         rankedListMeta.push({ source: "fts", queryType: "lex", query: q.text });
       }
@@ -3206,7 +3314,7 @@ export async function hybridQuery(
         for (const r of vecResults) docidMap.set(r.filepath, r.docid);
         rankedLists.push(vecResults.map(r => ({
           file: r.filepath, displayPath: r.displayPath,
-          title: r.title, body: r.body || "", score: r.score,
+          title: r.title, body: r.body || "", score: r.score, hash: r.hash,
         })));
         rankedListMeta.push({
           source: "vec",
@@ -3257,7 +3365,7 @@ export async function hybridQuery(
   // Step 7: Blend RRF position score with reranker score
   // Position-aware weights: top retrieval results get more protection from reranker disagreement
   const candidateMap = new Map(candidates.map(c => [c.file, {
-    displayPath: c.displayPath, title: c.title, body: c.body,
+    displayPath: c.displayPath, title: c.title, body: c.body, hash: c.hash,
   }]));
   const rrfRankMap = new Map(candidates.map((c, i) => [c.file, i + 1]));
 
@@ -3271,9 +3379,9 @@ export async function hybridQuery(
     // Replace severe 1/rank penalty with a softer exponential decay.
     // Rank 1 = 1.0, Rank 2 = 0.83, Rank 3 = 0.69, Rank 4 = 0.57 ...
     const rrfScore = Math.max(0.01, Math.exp(-(rrfRank - 1) / 5.5));
-    const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score;
-
     const candidate = candidateMap.get(r.file);
+    const feedbackPenalty = getFeedbackPenalty(store.db, query, candidate?.hash);
+    const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score + feedbackPenalty;
     const chunkInfo = docChunkMap.get(r.file);
     const bestIdx = chunkInfo?.bestIdx ?? 0;
     const bestChunk = chunkInfo?.chunks[bestIdx]?.text || candidate?.body || "";
@@ -3293,6 +3401,7 @@ export async function hybridQuery(
       },
       rerankScore: r.score,
       blendedScore,
+      feedbackPenalty,
     } : undefined;
 
     return {
@@ -3493,7 +3602,7 @@ export async function structuredSearch(
           for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
           rankedLists.push(ftsResults.map(r => ({
             file: r.filepath, displayPath: r.displayPath,
-            title: r.title, body: r.body || "", score: r.score,
+            title: r.title, body: r.body || "", score: r.score, hash: r.hash,
           })));
           rankedListMeta.push({
             source: "fts",
@@ -3540,7 +3649,7 @@ export async function structuredSearch(
             for (const r of vecResults) docidMap.set(r.filepath, r.docid);
             rankedLists.push(vecResults.map(r => ({
               file: r.filepath, displayPath: r.displayPath,
-              title: r.title, body: r.body || "", score: r.score,
+              title: r.title, body: r.body || "", score: r.score, hash: r.hash,
             })));
             rankedListMeta.push({
               source: "vec",
@@ -3599,7 +3708,7 @@ export async function structuredSearch(
 
   // Step 6: Blend RRF position score with reranker score
   const candidateMap = new Map(candidates.map(c => [c.file, {
-    displayPath: c.displayPath, title: c.title, body: c.body,
+    displayPath: c.displayPath, title: c.title, body: c.body, hash: c.hash,
   }]));
   const rrfRankMap = new Map(candidates.map((c, i) => [c.file, i + 1]));
 
@@ -3613,9 +3722,9 @@ export async function structuredSearch(
     // Replace severe 1/rank penalty with a softer exponential decay.
     // Rank 1 = 1.0, Rank 2 = 0.83, Rank 3 = 0.69, Rank 4 = 0.57 ...
     const rrfScore = Math.max(0.01, Math.exp(-(rrfRank - 1) / 5.5));
-    const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score;
-
     const candidate = candidateMap.get(r.file);
+    const feedbackPenalty = getFeedbackPenalty(store.db, primaryQuery, candidate?.hash);
+    const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score + feedbackPenalty;
     const chunkInfo = docChunkMap.get(r.file);
     const bestIdx = chunkInfo?.bestIdx ?? 0;
     const bestChunk = chunkInfo?.chunks[bestIdx]?.text || candidate?.body || "";
@@ -3635,6 +3744,7 @@ export async function structuredSearch(
       },
       rerankScore: r.score,
       blendedScore,
+      feedbackPenalty,
     } : undefined;
 
     return {

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -702,7 +702,6 @@ function initializeDatabase(db: Database): void {
       hash_seq TEXT NOT NULL,
       signal INTEGER NOT NULL,
       created INTEGER NOT NULL DEFAULT (unixepoch()),
-      session TEXT,
       UNIQUE(query, hash_seq)
     )
   `);
@@ -852,7 +851,7 @@ export type Store = {
   insertEmbedding: (hash: string, seq: number, pos: number, embedding: Float32Array, model: string, embeddedAt: string) => void;
 
   // Corrective feedback
-  insertFeedback: (query: string, hashSeq: string, signal: -1 | 1, session?: string | null) => void;
+  insertFeedback: (query: string, hashSeq: string, signal: -1 | 1) => void;
   listFeedback: (query?: string) => FeedbackRecord[];
 
   // Watcher integrations
@@ -945,7 +944,7 @@ export function createStore(dbPath?: string): Store {
     getHashesForEmbedding: () => getHashesForEmbedding(db),
     clearAllEmbeddings: () => clearAllEmbeddings(db),
     insertEmbedding: (hash: string, seq: number, pos: number, embedding: Float32Array, model: string, embeddedAt: string) => insertEmbedding(db, hash, seq, pos, embedding, model, embeddedAt),
-    insertFeedback: (query: string, hashSeq: string, signal: -1 | 1, session?: string | null) => insertFeedback(db, query, hashSeq, signal, session),
+    insertFeedback: (query: string, hashSeq: string, signal: -1 | 1) => insertFeedback(db, query, hashSeq, signal),
     listFeedback: (query?: string) => listFeedback(db, query),
   };
 }
@@ -1112,7 +1111,6 @@ export type FeedbackRecord = {
   hashSeq: string;
   signal: -1 | 1;
   created: number;
-  session: string | null;
 };
 
 /**
@@ -2517,7 +2515,6 @@ export function insertFeedback(
   query: string,
   hashSeq: string,
   signal: -1 | 1,
-  session?: string | null,
 ): void {
   const normalizedQuery = normalizeFeedbackQuery(query);
   const normalizedHashSeq = normalizeHashSeq(hashSeq);
@@ -2526,24 +2523,24 @@ export function insertFeedback(
   if (signal !== -1 && signal !== 1) throw new Error("signal must be -1 or 1");
 
   db.prepare(`
-    INSERT INTO feedback (query, hash_seq, signal, session, created)
-    VALUES (?, ?, ?, ?, unixepoch())
+    INSERT INTO feedback (query, hash_seq, signal, created)
+    VALUES (?, ?, ?, unixepoch())
     ON CONFLICT(query, hash_seq)
-    DO UPDATE SET signal = excluded.signal, session = excluded.session, created = unixepoch()
-  `).run(normalizedQuery, normalizedHashSeq, signal, session ?? null);
+    DO UPDATE SET signal = excluded.signal, created = unixepoch()
+  `).run(normalizedQuery, normalizedHashSeq, signal);
 }
 
 export function listFeedback(db: Database, query?: string): FeedbackRecord[] {
   const normalized = query ? normalizeFeedbackQuery(query) : "";
   const rows = normalized
     ? db.prepare(`
-        SELECT id, query, hash_seq, signal, created, session
+        SELECT id, query, hash_seq, signal, created
         FROM feedback
         WHERE query LIKE ?
         ORDER BY created DESC, id DESC
       `).all(`%${normalized}%`)
     : db.prepare(`
-        SELECT id, query, hash_seq, signal, created, session
+        SELECT id, query, hash_seq, signal, created
         FROM feedback
         ORDER BY created DESC, id DESC
       `).all();
@@ -2554,28 +2551,45 @@ export function listFeedback(db: Database, query?: string): FeedbackRecord[] {
     hashSeq: String(row.hash_seq),
     signal: Number(row.signal) < 0 ? -1 : 1,
     created: Number(row.created),
-    session: row.session ?? null,
   }));
 }
 
-export function getFeedbackPenalty(db: Database, query: string, hash?: string): number {
+export function getFeedbackPenalties(db: Database, query: string, hashes: string[]): Map<string, number> {
   const normalizedQuery = normalizeFeedbackQuery(query);
-  if (!normalizedQuery || !hash) return 0;
-  const hashPrefix = `${hash}_%`;
+  if (!normalizedQuery || hashes.length === 0) return new Map();
+  const uniqueHashes = Array.from(new Set(hashes.filter(Boolean)));
+  if (uniqueHashes.length === 0) return new Map();
 
   const rows = db.prepare(`
-    SELECT signal
+    SELECT hash_seq, signal
     FROM feedback
-    WHERE query = ? AND hash_seq LIKE ?
-  `).all(normalizedQuery, hashPrefix) as { signal: number }[];
+    WHERE query = ?
+  `).all(normalizedQuery) as { hash_seq: string; signal: number }[];
 
-  if (rows.length === 0) return 0;
+  if (rows.length === 0) return new Map();
 
-  let penalty = 0;
+  const penalties = new Map<string, number>();
+  for (const hash of uniqueHashes) penalties.set(hash, 0);
   for (const row of rows) {
-    penalty += row.signal < 0 ? -0.15 : 0.05;
+    const hashSeq = String(row.hash_seq || "");
+    const splitAt = hashSeq.lastIndexOf("_");
+    if (splitAt <= 0) continue;
+    const hash = hashSeq.slice(0, splitAt);
+    if (!penalties.has(hash)) continue;
+
+    const current = penalties.get(hash) ?? 0;
+    // Phase 1 behavior: only demote negatively marked chunks.
+    penalties.set(hash, current + (row.signal < 0 ? -0.15 : 0));
   }
-  return clamp(penalty, -0.30, 0.10);
+  for (const [hash, penalty] of penalties) {
+    penalties.set(hash, clamp(penalty, -0.30, 0));
+  }
+  return penalties;
+}
+
+export function getFeedbackPenalty(db: Database, query: string, hash?: string): number {
+  if (!hash) return 0;
+  return getFeedbackPenalties(db, query, [hash]).get(hash) ?? 0;
 }
 
 // =============================================================================
@@ -3368,6 +3382,11 @@ export async function hybridQuery(
     displayPath: c.displayPath, title: c.title, body: c.body, hash: c.hash,
   }]));
   const rrfRankMap = new Map(candidates.map((c, i) => [c.file, i + 1]));
+  const feedbackPenaltyByHash = getFeedbackPenalties(
+    store.db,
+    query,
+    candidates.map(c => c.hash).filter((h): h is string => !!h),
+  );
 
   const blended = reranked.map(r => {
     const rrfRank = rrfRankMap.get(r.file) || candidateLimit;
@@ -3380,7 +3399,7 @@ export async function hybridQuery(
     // Rank 1 = 1.0, Rank 2 = 0.83, Rank 3 = 0.69, Rank 4 = 0.57 ...
     const rrfScore = Math.max(0.01, Math.exp(-(rrfRank - 1) / 5.5));
     const candidate = candidateMap.get(r.file);
-    const feedbackPenalty = getFeedbackPenalty(store.db, query, candidate?.hash);
+    const feedbackPenalty = candidate?.hash ? (feedbackPenaltyByHash.get(candidate.hash) ?? 0) : 0;
     const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score + feedbackPenalty;
     const chunkInfo = docChunkMap.get(r.file);
     const bestIdx = chunkInfo?.bestIdx ?? 0;
@@ -3711,6 +3730,11 @@ export async function structuredSearch(
     displayPath: c.displayPath, title: c.title, body: c.body, hash: c.hash,
   }]));
   const rrfRankMap = new Map(candidates.map((c, i) => [c.file, i + 1]));
+  const feedbackPenaltyByHash = getFeedbackPenalties(
+    store.db,
+    primaryQuery,
+    candidates.map(c => c.hash).filter((h): h is string => !!h),
+  );
 
   const blended = reranked.map(r => {
     const rrfRank = rrfRankMap.get(r.file) || candidateLimit;
@@ -3723,7 +3747,7 @@ export async function structuredSearch(
     // Rank 1 = 1.0, Rank 2 = 0.83, Rank 3 = 0.69, Rank 4 = 0.57 ...
     const rrfScore = Math.max(0.01, Math.exp(-(rrfRank - 1) / 5.5));
     const candidate = candidateMap.get(r.file);
-    const feedbackPenalty = getFeedbackPenalty(store.db, primaryQuery, candidate?.hash);
+    const feedbackPenalty = candidate?.hash ? (feedbackPenaltyByHash.get(candidate.hash) ?? 0) : 0;
     const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score + feedbackPenalty;
     const chunkInfo = docChunkMap.get(r.file);
     const bestIdx = chunkInfo?.bestIdx ?? 0;

--- a/schema-migration.ts
+++ b/schema-migration.ts
@@ -134,7 +134,7 @@ try {
   console.log(`  ${c.green}✓${c.reset} Triggers updated`);
 
   // Step 9: Corrective feedback table for Phase 1
-  console.log(`\n${c.yellow}8. Creating corrective feedback table...${c.reset}`);
+  console.log(`\n${c.yellow}9. Creating corrective feedback table...${c.reset}`);
   db.exec(`
     CREATE TABLE IF NOT EXISTS feedback (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -142,7 +142,6 @@ try {
       hash_seq TEXT NOT NULL,
       signal INTEGER NOT NULL,
       created INTEGER NOT NULL DEFAULT (unixepoch()),
-      session TEXT,
       UNIQUE(query, hash_seq)
     )
   `);

--- a/schema-migration.ts
+++ b/schema-migration.ts
@@ -133,6 +133,22 @@ try {
   `);
   console.log(`  ${c.green}✓${c.reset} Triggers updated`);
 
+  // Step 9: Corrective feedback table for Phase 1
+  console.log(`\n${c.yellow}8. Creating corrective feedback table...${c.reset}`);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS feedback (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      query TEXT NOT NULL,
+      hash_seq TEXT NOT NULL,
+      signal INTEGER NOT NULL,
+      created INTEGER NOT NULL DEFAULT (unixepoch()),
+      session TEXT,
+      UNIQUE(query, hash_seq)
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_feedback_query ON feedback(query)`);
+  console.log(`  ${c.green}✓${c.reset} Feedback table ready`);
+
   // Commit transaction
   db.exec("COMMIT");
 

--- a/specs/command-line.test.ts
+++ b/specs/command-line.test.ts
@@ -570,6 +570,39 @@ describe("CLI Error Handling", () => {
   });
 });
 
+describe("CLI Feedback Command", () => {
+  test("stores and lists feedback as JSON", async () => {
+    const put = await runQmd([
+      "feedback",
+      "--irrelevant",
+      "--query", "deploy k8s",
+      "--chunk", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:0",
+      "--json",
+    ]);
+    expect(put.exitCode).toBe(0);
+    const putJson = JSON.parse(put.stdout);
+    expect(putJson.stored).toBe(true);
+    expect(putJson.signal).toBe("irrelevant");
+
+    const list = await runQmd(["feedback", "list", "--query", "deploy", "--json"]);
+    expect(list.exitCode).toBe(0);
+    const listJson = JSON.parse(list.stdout);
+    expect(Array.isArray(listJson.feedback)).toBe(true);
+    expect(listJson.feedback.length).toBeGreaterThan(0);
+    expect(listJson.feedback[0].query).toContain("deploy");
+  });
+
+  test("rejects invalid usage when signal flag is missing", async () => {
+    const res = await runQmd([
+      "feedback",
+      "--query", "deploy k8s",
+      "--chunk", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:0",
+    ]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("Usage: kindx feedback");
+  });
+});
+
 describe("CLI Output Formats", () => {
   beforeEach(async () => {
     await runQmd(["collection", "add", "."]);

--- a/specs/feedback.test.ts
+++ b/specs/feedback.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createStore,
+  insertContent,
+  insertDocument,
+  structuredSearch,
+  insertFeedback,
+  listFeedback,
+  getFeedbackPenalty,
+} from "../engine/repository.js";
+
+const openStores: ReturnType<typeof createStore>[] = [];
+const cleanupDirs: string[] = [];
+
+async function createTestStore(prefix: string): Promise<ReturnType<typeof createStore>> {
+  const dir = await mkdtemp(join(tmpdir(), `kindx-${prefix}-`));
+  cleanupDirs.push(dir);
+  const dbPath = join(dir, "index.sqlite");
+  const store = createStore(dbPath);
+  openStores.push(store);
+  return store;
+}
+
+afterEach(async () => {
+  while (openStores.length > 0) {
+    const s = openStores.pop();
+    s?.close();
+  }
+  while (cleanupDirs.length > 0) {
+    const d = cleanupDirs.pop();
+    if (!d) continue;
+    await rm(d, { recursive: true, force: true });
+  }
+});
+
+describe("corrective feedback", () => {
+  test("stores and lists feedback with upsert semantics", async () => {
+    const store = await createTestStore("feedback-list");
+    insertFeedback(store.db, "Deploy k8s", "hash_a_0", -1);
+    insertFeedback(store.db, "Deploy k8s", "hash_a_0", 1);
+
+    const all = listFeedback(store.db);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.query).toBe("deploy k8s");
+    expect(all[0]?.signal).toBe(1);
+
+    const filtered = listFeedback(store.db, "deploy");
+    expect(filtered).toHaveLength(1);
+  });
+
+  test("applies negative penalty for matching query+hash", async () => {
+    const store = await createTestStore("feedback-penalty");
+    insertFeedback(store.db, "deploy", "hash_a_0", -1);
+    insertFeedback(store.db, "deploy", "hash_a_1", -1);
+    const penalty = getFeedbackPenalty(store.db, "deploy", "hash_a");
+    expect(penalty).toBeLessThan(0);
+    expect(penalty).toBeGreaterThanOrEqual(-0.3);
+  });
+
+  test("structured search demotes previously downvoted document on second pass", async () => {
+    const backingStore = await createTestStore("feedback-structured");
+    const now = new Date().toISOString();
+
+    insertContent(backingStore.db, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "Deploy guide for Kubernetes rollouts", now);
+    insertDocument(
+      backingStore.db,
+      "docs",
+      "deploy-a.md",
+      "Deploy A",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      now,
+    );
+    insertContent(backingStore.db, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "Deployment checklist and troubleshooting", now);
+    insertDocument(
+      backingStore.db,
+      "docs",
+      "deploy-b.md",
+      "Deploy B",
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      now,
+      now,
+    );
+
+    const fakeStore: any = {
+      db: backingStore.db,
+      searchFTS: () => [
+        {
+          filepath: "kindx://docs/deploy-a.md",
+          displayPath: "docs/deploy-a.md",
+          title: "Deploy A",
+          hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          docid: "aaaaaa",
+          collectionName: "docs",
+          modifiedAt: "",
+          bodyLength: 40,
+          body: "Deploy guide for Kubernetes rollouts",
+          context: null,
+          score: 0.95,
+          source: "fts",
+        },
+        {
+          filepath: "kindx://docs/deploy-b.md",
+          displayPath: "docs/deploy-b.md",
+          title: "Deploy B",
+          hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          docid: "bbbbbb",
+          collectionName: "docs",
+          modifiedAt: "",
+          bodyLength: 42,
+          body: "Deployment checklist and troubleshooting",
+          context: null,
+          score: 0.85,
+          source: "fts",
+        },
+      ],
+      searchVec: async () => [],
+      rerank: async (_query: string, docs: { file: string; text: string }[]) =>
+        docs.map((d) => ({ file: d.file, score: 0.8 })),
+      getContextForFile: () => null,
+    };
+
+    const before = await structuredSearch(fakeStore, [{ type: "lex", query: "deploy" }], {
+      limit: 2,
+      candidateLimit: 2,
+    });
+    expect(before[0]?.file).toBe("kindx://docs/deploy-a.md");
+
+    insertFeedback(backingStore.db, "deploy", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_0", -1);
+
+    const after = await structuredSearch(fakeStore, [{ type: "lex", query: "deploy" }], {
+      limit: 2,
+      candidateLimit: 2,
+    });
+    expect(after[0]?.file).toBe("kindx://docs/deploy-b.md");
+  });
+});

--- a/specs/mcp.test.ts
+++ b/specs/mcp.test.ts
@@ -1071,7 +1071,7 @@ describe("MCP HTTP Transport", () => {
         name: "kindx_feedback",
         arguments: {
           query: "readme",
-          chunkId: "#hash1:0",
+          chunkId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:0",
           signal: "irrelevant",
         },
       },

--- a/specs/mcp.test.ts
+++ b/specs/mcp.test.ts
@@ -1020,6 +1020,7 @@ describe("MCP HTTP Transport", () => {
     expect(toolNames).toContain("query");
     expect(toolNames).toContain("get");
     expect(toolNames).toContain("status");
+    expect(toolNames).toContain("kindx_feedback");
   });
 
   test("POST /mcp tools/call query returns results", async () => {
@@ -1054,6 +1055,31 @@ describe("MCP HTTP Transport", () => {
     expect(status).toBe(200);
     expect(json.result).toBeDefined();
     expect(json.result.content.length).toBeGreaterThan(0);
+  });
+
+  test("POST /mcp tools/call kindx_feedback stores feedback", async () => {
+    await mcpRequest({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: {
+        name: "kindx_feedback",
+        arguments: {
+          query: "readme",
+          chunkId: "#hash1:0",
+          signal: "irrelevant",
+        },
+      },
+    });
+    expect(status).toBe(200);
+    expect(json.result.isError).not.toBe(true);
+    expect(json.result.structuredContent.stored).toBe(true);
+    expect(json.result.structuredContent.signal).toBe("irrelevant");
   });
 
   test("server uses dbPath instead of default index.sqlite", async () => {


### PR DESCRIPTION
Closes #12

## Summary
- add a Phase 1 corrective feedback loop for query-time demotion in hybrid/structured ranking
- add persistent `feedback` schema with upsert/list operations (`query`, `hash_seq`, `signal`, optional `session`)
- add `kindx feedback` CLI command group (`--relevant|--irrelevant`, `list`)
- add MCP tool `kindx_feedback` for agent feedback submission
- update migration script and docs for feedback interfaces

## Issue #12 Scope
This PR implements **Phase 1 only** (negative-feedback demotion loop), per the agreed plan.

## Acceptance Mapping
- [x] feedback signals are stored (`kindx feedback ...`)
- [x] query-time demotion applies when feedback exists for matching query/hash
- [x] MCP feedback tool is registered and callable
- [x] tests added for storage/listing/penalty + CLI + MCP

## Validation
- `npm run build`
- `npm test` (14 files, 588 tests passed)
- model-free real corpus verification on `specs/eval-docs`: second pass ranking demoted the previously downvoted top document

## Notes
- this PR is isolated to issue #12 scope and excludes unrelated local memory-subsystem work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corrective feedback (Phase 1): store relevance (relevant/irrelevant) for query+chunk pairs
  * `kindx feedback` CLI to record and list feedback; feedback influences search ranking
  * New database feedback table and related store APIs to persist and apply penalties

* **Documentation**
  * README updated with usage examples and registered `kindx_feedback` tool

* **Tests**
  * New CLI, unit, and MCP tests covering feedback flows and scoring integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->