### PR TITLE
chore(config): include all conventional commit types in release changelog

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,14 +1,56 @@
 {
-    "packages": {
-        ".": {
-            "release-type": "node",
-            "package-name": "@ambicuity/kindx",
-            "changelog-path": "CHANGELOG.md",
-            "bump-minor-pre-major": true,
-            "bump-patch-for-minor-pre-major": true,
-            "draft": false,
-            "prerelease": false
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "package-name": "@ambicuity/kindx",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "chore",
+          "section": "Chores"
+        },
+        {
+          "type": "ci",
+          "section": "CI"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
         }
-    },
-    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+      ]
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
## Summary
- add explicit changelog sections to Release Please config
- include feat/fix/perf/refactor/docs/test/chore/ci/build/revert
- keep release workflow unchanged

## Why
Merged PRs with non-feat/fix types were not being grouped in CHANGELOG output.

## Validation
- config JSON validated with jq

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to improve changelog organization and formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->