### PR TITLE
fix(reference): address ai review follow-ups from #77

### DIFF
--- a/packages/kindx-client/specs/real-data.test.ts
+++ b/packages/kindx-client/specs/real-data.test.ts
@@ -167,8 +167,13 @@ describe("KindxClient real data", () => {
 
     const file = target?.file || result.results[0]!.file;
     const doc = await client.get({ file });
-    const textContent = doc.content?.find((item) => item.type === "resource");
+    const textContent = doc.content?.find(
+      (
+        item
+      ): item is Extract<NonNullable<typeof doc.content>[number], { type: "resource" }> =>
+        item.type === "resource"
+    );
     expect(textContent).toBeTruthy();
-    expect((textContent as any).resource.text).toContain("Rate Limiting");
+    expect(textContent?.resource.text).toContain("Rate Limiting");
   });
 });

--- a/packages/kindx-client/src/index.ts
+++ b/packages/kindx-client/src/index.ts
@@ -57,6 +57,7 @@ export class KindxClient {
   private readonly timeoutMs: number;
   private readonly token?: string;
   private mcpSessionId?: string;
+  private rpcIdCounter = 0;
 
   constructor(options: KindxClientOptions) {
     this.baseUrl = trimTrailingSlashes(options.baseUrl);
@@ -109,9 +110,9 @@ export class KindxClient {
 
   private async callTool(name: string, args: Record<string, unknown>): Promise<KindxMcpToolResult> {
     const sessionId = await this.ensureSession();
-    const rpc = await this.postJson(`${this.baseUrl}/mcp`, {
+    const rpc = await this.postJson<JsonRpcResponse>(`${this.baseUrl}/mcp`, {
       jsonrpc: "2.0",
-      id: Date.now(),
+      id: this.nextRpcId(),
       method: "tools/call",
       params: {
         name,
@@ -128,11 +129,11 @@ export class KindxClient {
   private async ensureSession(): Promise<string> {
     if (this.mcpSessionId) return this.mcpSessionId;
 
-    const response = await this.postJson(
+    const response = await this.postJson<JsonRpcResponse>(
       `${this.baseUrl}/mcp`,
       {
         jsonrpc: "2.0",
-        id: Date.now(),
+        id: this.nextRpcId(),
         method: "initialize",
         params: {
           protocolVersion: "2025-03-26",
@@ -155,6 +156,11 @@ export class KindxClient {
     return response.sessionId;
   }
 
+  private nextRpcId(): number {
+    this.rpcIdCounter += 1;
+    return this.rpcIdCounter;
+  }
+
   private parseJsonRpc(body: unknown): JsonRpcResponse {
     const rpc = body as JsonRpcResponse;
     if (rpc?.error) {
@@ -165,12 +171,24 @@ export class KindxClient {
     return rpc;
   }
 
-  private async postJson(
+  private async postJson<T>(
+    url: string,
+    body: unknown,
+    headers?: Record<string, string>,
+    includeResponseHeaders?: false,
+  ): Promise<T>;
+  private async postJson<T>(
+    url: string,
+    body: unknown,
+    headers: Record<string, string> | undefined,
+    includeResponseHeaders: true,
+  ): Promise<{ body: T; sessionId?: string }>;
+  private async postJson<T>(
     url: string,
     body: unknown,
     headers?: Record<string, string>,
     includeResponseHeaders: boolean = false,
-  ): Promise<any> {
+  ): Promise<T | { body: T; sessionId?: string }> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 
@@ -192,9 +210,9 @@ export class KindxClient {
       });
 
       const text = await res.text();
-      let parsed: unknown;
+      let parsed: T;
       try {
-        parsed = text ? JSON.parse(text) : {};
+        parsed = (text ? JSON.parse(text) : {}) as T;
       } catch {
         throw new KindxClientError("Invalid JSON response from KINDX server", {
           status: res.status,

--- a/python/kindx-langchain/src/kindx_langchain/retriever.py
+++ b/python/kindx-langchain/src/kindx_langchain/retriever.py
@@ -83,6 +83,3 @@ class KindxRetriever(BaseRetriever):
     def _get_relevant_documents(self, query: str, **_: Any) -> List[Document]:
         results = self._search(query)
         return [self._to_document(item) for item in results]
-
-    def invoke(self, query: str) -> List[Document]:
-        return self._get_relevant_documents(query)


### PR DESCRIPTION
## Summary
Follow-up cleanup for merged PR #77 to address unresolved Gemini medium comments without changing public SDK behavior.

### Changes
- @ambicuity/kindx-client
  - replaced Date.now() JSON-RPC IDs with monotonic counter (nextRpcId())
  - added typed overloads for postJson to eliminate Promise<any> and provide typed response variants
- packages/kindx-client/specs/real-data.test.ts
  - replaced (textContent as any) with typed narrowing for resource content
- python/kindx-langchain
  - removed redundant KindxRetriever.invoke() override

## Validation
- npx tsc --noEmit
- npm run build -w @ambicuity/kindx-client
- npm run test -w @ambicuity/kindx-client
- python3 -m unittest discover -s python/kindx-langchain/tests -v
- npm run build:all

## Context
- AI-review follow-up for: #77

Closes #29