### PR TITLE
feat(engine): align live indexing and mcp daemon watch flow (closes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ By default, the MCP server uses stdio (launched as a subprocess per client). For
 # Foreground
 kindx mcp --http                # localhost:8181
 kindx mcp --http --port 8080    # custom port
+kindx mcp --http --watch        # start HTTP MCP + live watcher in one process
 
 # Persistent daemon
 kindx mcp --http --daemon       # writes PID to ~/.cache/kindx/mcp.pid
+kindx mcp --http --daemon --watch
 kindx mcp stop                  # terminate via PID file
 kindx status                    # reports "MCP: running (PID ...)"
 ```

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -2511,6 +2511,7 @@ function parseCLI() {
       // MCP HTTP transport options
       http: { type: "boolean" },
       daemon: { type: "boolean" },
+      watch: { type: "boolean" },
       port: { type: "string" },
     },
     allowPositionals: true,
@@ -2632,7 +2633,7 @@ function showHelp(): void {
   console.log("");
   console.log("  kindx status                    - View index + collection health");
   console.log("  kindx watch [collections...]    - Real-time incremental indexing daemon");
-  console.log("  kindx mcp --http [--daemon]     - Run the shared MCP HTTP server");
+  console.log("  kindx mcp --http [--daemon] [--watch] - Run the shared MCP HTTP server");
   console.log("  kindx mcp stop                  - Stop the MCP HTTP daemon");
   console.log("  kindx migrate chroma <path>     - Migrate a ChromaDB sqlite file to KINDX");
   console.log("  kindx migrate openclaw <path>   - Migrate an OpenCLAW repository to use KINDX");
@@ -3304,9 +3305,10 @@ if (isMain) {
           const selfPath = fileURLToPath(import.meta.url);
           const iName = cli.values.index as string | undefined;
           const indexFlag = iName ? ["--index", iName] : [];
+          const watchFlag = cli.values.watch ? ["--watch"] : [];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port), ...indexFlag]
-            : [selfPath, "mcp", "--http", "--port", String(port), ...indexFlag];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port), ...watchFlag, ...indexFlag]
+            : [selfPath, "mcp", "--http", "--port", String(port), ...watchFlag, ...indexFlag];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -3326,7 +3328,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("./protocol.js");
         try {
-          await startMcpHttpServer(port, { dbPath: storeDbPathOverride });
+          await startMcpHttpServer(port, { dbPath: storeDbPathOverride, watch: !!cli.values.watch });
         } catch (e: any) {
           if (e?.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);

--- a/engine/protocol.ts
+++ b/engine/protocol.ts
@@ -654,8 +654,14 @@ export type HttpServerHandle = {
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
  * Binds to localhost only. Returns a handle for shutdown and port discovery.
  */
-export async function startMcpHttpServer(port: number, options?: { quiet?: boolean; dbPath?: string }): Promise<HttpServerHandle> {
+export async function startMcpHttpServer(port: number, options?: { quiet?: boolean; dbPath?: string; watch?: boolean }): Promise<HttpServerHandle> {
   const store = createStore(options?.dbPath);
+  let watchDaemon: { start: (collections?: string[]) => Promise<void>; stop: () => Promise<void> } | null = null;
+  if (options?.watch) {
+    const { WatchDaemon } = await import("./watcher.js");
+    watchDaemon = new WatchDaemon(store);
+    await watchDaemon.start();
+  }
   startDaemonPreload();
 
   // Read token once at startup. Undefined / empty = auth disabled (single-user local mode).
@@ -911,6 +917,10 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
   const stop = async () => {
     if (stopping) return;
     stopping = true;
+    if (watchDaemon) {
+      await watchDaemon.stop();
+      watchDaemon = null;
+    }
     for (const transport of sessions.values()) {
       await transport.close();
     }

--- a/engine/watcher.ts
+++ b/engine/watcher.ts
@@ -1,7 +1,8 @@
 import chokidar, { type FSWatcher } from "chokidar";
 import { resolve, relative as pathRelative } from "path";
 import { realpathSync } from "fs";
-import { type Store } from "./repository.js";
+import { getDefaultLLM } from "./inference.js";
+import { DEFAULT_EMBED_MODEL, extractTitle, formatDocForEmbedding, type Store, chunkDocumentByTokens } from "./repository.js";
 
 interface WatchEvent {
   type: "add" | "change" | "unlink";
@@ -215,6 +216,7 @@ export class WatchDaemon {
 
     const startMs = Date.now();
     let processed = 0;
+    const changedForEmbedding: { hash: string; relativePath: string }[] = [];
     
     // Format current time
     const now = new Date().toLocaleTimeString();
@@ -238,6 +240,10 @@ export class WatchDaemon {
             if (result === "embedded") {
               console.log(`  ${c.green}[+]${c.reset} Re-indexed: ${event.relativePath}`);
               processed++;
+              const activeDoc = store.findActiveDocument(event.collectionName, event.relativePath);
+              if (activeDoc?.hash) {
+                changedForEmbedding.push({ hash: activeDoc.hash, relativePath: event.relativePath });
+              }
             } else if (result === "unchanged") {
               // hash matched, no change needed
               // console.log(`  [=] Unchanged: ${event.relativePath}`);
@@ -248,6 +254,10 @@ export class WatchDaemon {
         } catch (err) {
           console.error(`  ${c.red}[!]${c.reset} Error processing ${event.relativePath}:`, err);
         }
+      }
+
+      if (changedForEmbedding.length > 0) {
+        await this.embedChangedDocuments(changedForEmbedding);
       }
       
       if (processed > 0) {
@@ -264,6 +274,87 @@ export class WatchDaemon {
           this.processQueue().catch(err => console.error(err));
         }, 50);
       }
+    }
+  }
+
+  /**
+   * Batch-embed recently changed documents when a vector index exists.
+   */
+  private async embedChangedDocuments(changedDocs: { hash: string; relativePath: string }[]): Promise<void> {
+    const store = this.store as any;
+    const db = store.db;
+    if (!db) return;
+
+    const hasVecTable = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
+    if (!hasVecTable) return;
+
+    const docByHash = new Map<string, { relativePath: string; body: string }>();
+    for (const doc of changedDocs) {
+      if (docByHash.has(doc.hash)) continue;
+      const row = db.prepare(`SELECT doc FROM content WHERE hash = ? LIMIT 1`).get(doc.hash) as { doc?: string } | undefined;
+      if (!row?.doc || !row.doc.trim()) continue;
+      docByHash.set(doc.hash, { relativePath: doc.relativePath, body: row.doc });
+    }
+
+    if (docByHash.size === 0) return;
+
+    const chunks: { hash: string; seq: number; pos: number; title: string; text: string }[] = [];
+    for (const [hash, payload] of docByHash.entries()) {
+      const title = extractTitle(payload.body, payload.relativePath);
+      const tokenChunks = await chunkDocumentByTokens(payload.body);
+      for (let i = 0; i < tokenChunks.length; i++) {
+        const chunk = tokenChunks[i]!;
+        chunks.push({
+          hash,
+          seq: i,
+          pos: chunk.pos,
+          title,
+          text: chunk.text,
+        });
+      }
+    }
+
+    if (chunks.length === 0) return;
+
+    const llm = getDefaultLLM();
+    const first = chunks[0]!;
+    const firstEmbedding = await llm.embed(formatDocForEmbedding(first.text, first.title));
+    if (!firstEmbedding) return;
+    store.ensureVecTable(firstEmbedding.embedding.length);
+
+    const now = new Date().toISOString();
+    const BATCH_SIZE = 32;
+    let inserted = 0;
+
+    for (let i = 0; i < chunks.length; i += BATCH_SIZE) {
+      const batch = chunks.slice(i, i + BATCH_SIZE);
+      const texts = batch.map((chunk) => formatDocForEmbedding(chunk.text, chunk.title));
+      let embeddings = await llm.embedBatch(texts);
+
+      // Fallback per-item only for failed positions.
+      for (let j = 0; j < batch.length; j++) {
+        if (embeddings[j]) continue;
+        embeddings[j] = await llm.embed(texts[j]!);
+      }
+
+      for (let j = 0; j < batch.length; j++) {
+        const embedding = embeddings[j];
+        if (!embedding) continue;
+        const chunk = batch[j]!;
+        store.insertEmbedding(
+          chunk.hash,
+          chunk.seq,
+          chunk.pos,
+          new Float32Array(embedding.embedding),
+          DEFAULT_EMBED_MODEL,
+          now
+        );
+        inserted++;
+      }
+    }
+
+    if (inserted > 0) {
+      console.log(`[${new Date().toLocaleTimeString()}] Embedded ${inserted} chunk(s) from ${docByHash.size} changed file(s).`);
     }
   }
 }

--- a/specs/command-line.test.ts
+++ b/specs/command-line.test.ts
@@ -1266,8 +1266,10 @@ describe("mcp http daemon", () => {
   }
 
   /** Spawn a foreground HTTP server (non-blocking) and return the process */
-  function spawnHttpServer(port: number): import("child_process").ChildProcess {
-    const proc = spawn(process.execPath, [kindxBin, "mcp", "--http", "--port", String(port)], {
+  function spawnHttpServer(port: number, watch = false): import("child_process").ChildProcess {
+    const args = [kindxBin, "mcp", "--http", "--port", String(port)];
+    if (watch) args.push("--watch");
+    const proc = spawn(process.execPath, args, {
       cwd: fixturesDir,
       env: {
         ...process.env,
@@ -1347,6 +1349,24 @@ describe("mcp http daemon", () => {
       expect(body.status).toBe("ok");
       expect(typeof body.warmed).toBe("boolean");
       expect(body.models).toBeDefined();
+    } finally {
+      proc.kill("SIGTERM");
+      await new Promise(r => proc.on("close", r));
+    }
+  });
+
+  test("foreground HTTP server accepts --watch", async () => {
+    const port = randomPort();
+    const proc = spawnHttpServer(port, true);
+
+    try {
+      const ready = await waitForServer(port);
+      expect(ready).toBe(true);
+
+      const res = await fetch(`http://localhost:${port}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("ok");
     } finally {
       proc.kill("SIGTERM");
       await new Promise(r => proc.on("close", r));


### PR DESCRIPTION
## Summary
This PR implements the missing live-watch pieces identified while auditing issue #23 against `origin/main`:

- Adds `kindx mcp --http [--daemon] --watch` so watcher + MCP HTTP can run in one process.
- Adds batched live embedding for changed files (when vector index exists) using watcher debounce windows.
- Extends tests to cover `mcp --http --watch`.
- Updates README examples for MCP watch mode.

## Requirement Matrix (Issue #23)
- `kindx watch` daemon: **Implemented**
- fs event handling (`add/change/unlink`): **Implemented**
- 500ms debounced batching: **Implemented**
- batched `embedBatch` on changed files when vector index exists: **Implemented in watcher batch flow**
- `kindx mcp --http --daemon --watch`: **Implemented**
- dedicated `worker_threads` indexer file: **Not introduced** (current implementation uses in-process serialized queue + batch embedding for WAL safety)

## Local Validation
- Full test suite: `593 passed`
- Focused daemon/watch tests: passed
- Real-data manual runs:
  - watcher add/change/unlink updates index as expected
  - MCP daemon with `--watch` updates index live and reports both MCP and Watch running

## AI Reviewer Assessment
Existing AI bot comments in candidate context were non-actionable "review skipped" status messages (CodeRabbit on bot-authored PRs).
Result: **Not relevant** to code correctness; no actionable findings to port.

Closes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--watch` option for MCP HTTP server (available in both daemon and foreground modes)

* **Documentation**
  * Updated README with examples demonstrating the new `--watch` option

* **Tests**
  * Added integration test for the `--watch` functionality with foreground HTTP server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->