### PR TITLE
fix(engine): restore BM25 relevance for contiguous CJK text

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ Models are downloaded from HuggingFace and cached in `~/.cache/kindx/models/`.
 
 Override the default embedding model via the `KINDX_EMBED_MODEL` environment variable. Required for multilingual corpora (CJK, Arabic, etc.) where `embeddinggemma-300M` has limited coverage.
 
+BM25 keyword search now normalizes CJK text at both index and query time (with `Intl.Segmenter` plus CJK bigram fallback), so `kindx search` remains effective even for contiguous Chinese/Japanese/Korean text without whitespace.
+
 ```bash
 # Use Qwen3-Embedding-0.6B for multilingual corpus (CJK) support
 export KINDX_EMBED_MODEL="hf:Qwen/Qwen3-Embedding-0.6B-GGUF/qwen3-embedding-0.6b-Q8_0.gguf"

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -593,6 +593,127 @@ export function toVirtualPath(db: Database, absolutePath: string): string | null
 // Database initialization
 // =============================================================================
 
+const CJK_CHAR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+
+function hasCjk(text: string): boolean {
+  return CJK_CHAR_RE.test(text);
+}
+
+function countScriptChars(text: string): { han: number; kana: number; hangul: number } {
+  let han = 0;
+  let kana = 0;
+  let hangul = 0;
+  for (const ch of text) {
+    if (/\p{Script=Han}/u.test(ch)) han++;
+    if (/\p{Script=Hiragana}|\p{Script=Katakana}/u.test(ch)) kana++;
+    if (/\p{Script=Hangul}/u.test(ch)) hangul++;
+  }
+  return { han, kana, hangul };
+}
+
+function detectCjkLanguage(text: string): 'zh' | 'ja' | 'ko' | null {
+  const counts = countScriptChars(text);
+  if (counts.hangul > 0) return 'ko';
+  if (counts.kana > 0) return 'ja';
+  if (counts.han > 0) return 'zh';
+  return null;
+}
+
+const segmenterCache = new Map<string, Intl.Segmenter>();
+
+function getWordSegmenter(lang: 'zh' | 'ja' | 'ko'): Intl.Segmenter {
+  const cached = segmenterCache.get(lang);
+  if (cached) return cached;
+  const seg = new Intl.Segmenter(lang, { granularity: 'word' });
+  segmenterCache.set(lang, seg);
+  return seg;
+}
+
+function sanitizeLexToken(term: string): string {
+  return term.replace(/[^\p{L}\p{N}'_]/gu, '').toLowerCase();
+}
+
+function cjkBigrams(token: string): string[] {
+  const chars = Array.from(token);
+  if (chars.length < 2) return [];
+  const grams: string[] = [];
+  for (let i = 0; i < chars.length - 1; i++) {
+    const gram = `${chars[i]}${chars[i + 1]}`;
+    if (gram.trim().length > 0) grams.push(gram);
+  }
+  return grams;
+}
+
+function shouldEmitCjkBigrams(token: string): boolean {
+  const cjkChars = Array.from(token).filter(ch => CJK_CHAR_RE.test(ch)).length;
+  return cjkChars >= 4;
+}
+
+function normalizeTextForFts(input: string): string {
+  if (!input) return '';
+  if (!hasCjk(input)) return input;
+
+  const lang = detectCjkLanguage(input);
+  if (!lang) return input;
+
+  const segmenter = getWordSegmenter(lang);
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const segment of segmenter.segment(input)) {
+    if (!segment.isWordLike) continue;
+    const token = sanitizeLexToken(segment.segment);
+    if (!token) continue;
+    if (shouldEmitCjkBigrams(token)) {
+      let emitted = false;
+      for (const gram of cjkBigrams(token)) {
+        if (gram && !seen.has(gram)) {
+          tokens.push(gram);
+          seen.add(gram);
+          emitted = true;
+        }
+      }
+      if (emitted) continue;
+    }
+    if (!seen.has(token)) {
+      tokens.push(token);
+      seen.add(token);
+    }
+  }
+
+  // Fallback for runtimes where segmentation yields no word-like CJK tokens.
+  if (tokens.length === 0) {
+    const fallback = sanitizeLexToken(input);
+    if (fallback) return fallback;
+  }
+
+  return tokens.join(' ');
+}
+
+function normalizeLexTermTokens(input: string): string[] {
+  const normalized = normalizeTextForFts(input);
+  if (!normalized) return [];
+  return normalized
+    .split(/\s+/)
+    .map(token => sanitizeLexToken(token))
+    .filter(token => token.length > 0);
+}
+
+function registerFtsNormalizerFunction(db: Database): boolean {
+  const dbWithFn = db as Database & {
+    function?: (name: string, fn: (...args: unknown[]) => unknown) => void;
+  };
+  if (typeof dbWithFn.function !== 'function') return false;
+
+  try {
+    dbWithFn.function("kindx_fts_normalize", (value: unknown) => {
+      if (typeof value !== "string") return "";
+      return normalizeTextForFts(value);
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function createSqliteVecUnavailableError(reason: string): Error {
   return new Error(
@@ -622,6 +743,8 @@ export function verifySqliteVecLoaded(db: Database): void {
 let _sqliteVecAvailable: boolean | null = null;
 
 function initializeDatabase(db: Database): void {
+  const hasFtsNormalizer = registerFtsNormalizerFunction(db);
+
   try {
     loadSqliteVec(db);
     verifySqliteVecLoaded(db);
@@ -707,6 +830,17 @@ function initializeDatabase(db: Database): void {
   `);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_feedback_query ON feedback(query)`);
 
+  // Upgrade legacy test/runtime schemas that created different FTS column layouts.
+  const ftsInfo = db.prepare(`PRAGMA table_info(documents_fts)`).all() as { name: string }[];
+  if (ftsInfo.length > 0) {
+    const requiredCols = new Set(["filepath", "title", "body"]);
+    const existingCols = new Set(ftsInfo.map(col => col.name));
+    const hasExpectedSchema = Array.from(requiredCols).every(col => existingCols.has(col));
+    if (!hasExpectedSchema) {
+      db.exec(`DROP TABLE IF EXISTS documents_fts`);
+    }
+  }
+
   // FTS - index filepath (collection/path), title, and content
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
@@ -715,29 +849,38 @@ function initializeDatabase(db: Database): void {
     )
   `);
 
+  const ftsTitleExpr = hasFtsNormalizer ? `kindx_fts_normalize(new.title)` : `new.title`;
+  const ftsBodyExpr = hasFtsNormalizer
+    ? `(SELECT kindx_fts_normalize(doc) FROM content WHERE hash = new.hash)`
+    : `(SELECT doc FROM content WHERE hash = new.hash)`;
+
   // Triggers to keep FTS in sync
+  db.exec(`DROP TRIGGER IF EXISTS documents_ai`);
+  db.exec(`DROP TRIGGER IF EXISTS documents_ad`);
+  db.exec(`DROP TRIGGER IF EXISTS documents_au`);
+
   db.exec(`
-    CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents
+    CREATE TRIGGER documents_ai AFTER INSERT ON documents
     WHEN new.active = 1
     BEGIN
       INSERT INTO documents_fts(rowid, filepath, title, body)
       SELECT
         new.id,
         new.collection || '/' || new.path,
-        new.title,
-        (SELECT doc FROM content WHERE hash = new.hash)
+        ${ftsTitleExpr},
+        ${ftsBodyExpr}
       WHERE new.active = 1;
     END
   `);
 
   db.exec(`
-    CREATE TRIGGER IF NOT EXISTS documents_ad AFTER DELETE ON documents BEGIN
+    CREATE TRIGGER documents_ad AFTER DELETE ON documents BEGIN
       DELETE FROM documents_fts WHERE rowid = old.id;
     END
   `);
 
   db.exec(`
-    CREATE TRIGGER IF NOT EXISTS documents_au AFTER UPDATE ON documents
+    CREATE TRIGGER documents_au AFTER UPDATE ON documents
     BEGIN
       -- Delete from FTS if no longer active
       DELETE FROM documents_fts WHERE rowid = old.id AND new.active = 0;
@@ -747,11 +890,47 @@ function initializeDatabase(db: Database): void {
       SELECT
         new.id,
         new.collection || '/' || new.path,
-        new.title,
-        (SELECT doc FROM content WHERE hash = new.hash)
+        ${ftsTitleExpr},
+        ${ftsBodyExpr}
       WHERE new.active = 1;
     END
   `);
+
+  migrateFtsNormalization(db, hasFtsNormalizer);
+}
+
+const FTS_CJK_MIGRATION_VERSION = 1;
+
+function getUserVersion(db: Database): number {
+  const row = db.prepare(`PRAGMA user_version`).get() as { user_version?: number } | undefined;
+  return typeof row?.user_version === "number" ? row.user_version : 0;
+}
+
+function setUserVersion(db: Database, version: number): void {
+  db.exec(`PRAGMA user_version = ${version}`);
+}
+
+function migrateFtsNormalization(db: Database, hasFtsNormalizer: boolean): void {
+  const currentVersion = getUserVersion(db);
+  if (currentVersion >= FTS_CJK_MIGRATION_VERSION) return;
+
+  const titleExpr = hasFtsNormalizer ? `kindx_fts_normalize(d.title)` : `d.title`;
+  const bodyExpr = hasFtsNormalizer ? `kindx_fts_normalize(content.doc)` : `content.doc`;
+
+  db.exec(`DELETE FROM documents_fts`);
+  db.exec(`
+    INSERT INTO documents_fts(rowid, filepath, title, body)
+    SELECT
+      d.id,
+      d.collection || '/' || d.path,
+      ${titleExpr},
+      ${bodyExpr}
+    FROM documents d
+    JOIN content ON content.hash = d.hash
+    WHERE d.active = 1
+  `);
+
+  setUserVersion(db, FTS_CJK_MIGRATION_VERSION);
 }
 
 
@@ -2106,12 +2285,6 @@ export function getTopLevelPathsWithoutContext(db: Database, collectionName: str
 // FTS Search
 // =============================================================================
 
-function sanitizeFTS5Term(term: string): string {
-  // Preserve underscores so snake_case identifiers (e.g., my_function_name)
-  // are treated as single terms rather than being split into separate words.
-  return term.replace(/[^\p{L}\p{N}'_]/gu, '').toLowerCase();
-}
-
 /**
  * Parse lex query syntax into FTS5 query.
  *
@@ -2151,7 +2324,7 @@ function buildFTS5Query(query: string): string | null {
       const phrase = s.slice(start, i).trim();
       i++; // skip closing quote
       if (phrase.length > 0) {
-        const sanitized = phrase.split(/\s+/).map(t => sanitizeFTS5Term(t)).filter(t => t).join(' ');
+        const sanitized = normalizeLexTermTokens(phrase).join(' ');
         if (sanitized) {
           const ftsPhrase = `"${sanitized}"`;  // Exact phrase, no prefix match
           if (negated) {
@@ -2167,13 +2340,14 @@ function buildFTS5Query(query: string): string | null {
       while (i < s.length && !/[\s"]/.test(s[i]!)) i++;
       const term = s.slice(start, i);
 
-      const sanitized = sanitizeFTS5Term(term);
-      if (sanitized) {
-        const ftsTerm = `"${sanitized}"*`;  // Prefix match
+      const tokens = normalizeLexTermTokens(term);
+      if (tokens.length > 0) {
+        const ftsToken = tokens.map(token => `"${token}"*`).join(' AND ');
+        const wrapped = tokens.length > 1 ? `(${ftsToken})` : ftsToken;
         if (negated) {
-          negative.push(ftsTerm);
+          negative.push(wrapped);
         } else {
-          positive.push(ftsTerm);
+          positive.push(wrapped);
         }
       }
     }

--- a/engine/runtime.ts
+++ b/engine/runtime.ts
@@ -37,6 +37,7 @@ export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
   loadExtension(path: string): void;
+  function?(name: string, ...rest: any[]): void;
   close(): void;
 }
 

--- a/specs/mcp.test.ts
+++ b/specs/mcp.test.ts
@@ -301,6 +301,67 @@ describe("MCP Server", () => {
       expect(filtered[0]).toHaveProperty("score");
       expect(filtered[0]).toHaveProperty("snippet");
     });
+
+    test("matches contiguous CJK keywords through real store indexing path", async () => {
+      const cjkConfigDir = await mkdtemp(join(tmpdir(), "kindx-mcp-cjk-config-"));
+      const cjkDbPath = join(tmpdir(), `kindx-mcp-cjk-${Date.now()}.sqlite`);
+      const prevConfigDir = process.env.KINDX_CONFIG_DIR;
+      const prevIndexName = process.env.KINDX_CONFIG_INDEX_NAME;
+
+      const cjkConfig: CollectionConfig = {
+        collections: {
+          cjk: {
+            path: "/tmp/cjk-docs",
+            pattern: "**/*.md",
+          },
+        },
+      };
+
+      try {
+        process.env.KINDX_CONFIG_DIR = cjkConfigDir;
+        setConfigIndexName(`mcp-cjk-${Date.now()}`);
+        await writeFile(join(cjkConfigDir, "index.yml"), YAML.stringify(cjkConfig));
+
+        const store = createStore(cjkDbPath);
+        const now = new Date().toISOString();
+        const hash = "cjkhash1";
+        const body = "数据库性能优化需要索引设计和事务管理";
+        store.insertContent(hash, body, now);
+        store.insertDocument("cjk", "docs/zh.md", "中文检索示例", hash, now, now);
+
+        const direct = searchFTS(store.db, "索引", 10, "cjk");
+        expect(direct.some(r => r.displayPath === "cjk/docs/zh.md")).toBe(true);
+
+        // Parity with MCP result shaping path (search + snippet extraction).
+        const structured = direct.map(r => ({
+          file: r.displayPath,
+          title: r.title,
+          score: Math.round(r.score * 100) / 100,
+          context: getContextForFile(store.db, r.filepath),
+          snippet: extractSnippet(r.body || "", "索引", 300, r.chunkPos).snippet,
+        }));
+        expect(structured.length).toBeGreaterThan(0);
+        expect(structured[0]!.file).toBe("cjk/docs/zh.md");
+
+        store.close();
+      } finally {
+        if (prevConfigDir === undefined) {
+          delete process.env.KINDX_CONFIG_DIR;
+        } else {
+          process.env.KINDX_CONFIG_DIR = prevConfigDir;
+        }
+        if (prevIndexName === undefined) {
+          delete process.env.KINDX_CONFIG_INDEX_NAME;
+        } else {
+          process.env.KINDX_CONFIG_INDEX_NAME = prevIndexName;
+        }
+        setConfigIndexName(prevIndexName || "index");
+
+        try { await unlink(cjkDbPath); } catch { }
+        try { await unlink(join(cjkConfigDir, "index.yml")); } catch { }
+        try { await rmdir(cjkConfigDir); } catch { }
+      }
+    });
   });
 
   // ===========================================================================

--- a/specs/store.test.ts
+++ b/specs/store.test.ts
@@ -1253,6 +1253,41 @@ describe("FTS Search", () => {
     await cleanupTestDb(store);
   });
 
+  test("searchFTS handles contiguous CJK text with mid-sentence keyword queries", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    await insertTestDocument(store.db, collectionName, {
+      name: "zh-cjk",
+      title: "中文检索示例",
+      body: "数据库性能优化需要索引设计和事务管理",
+      displayPath: "cjk/zh.md",
+    });
+    await insertTestDocument(store.db, collectionName, {
+      name: "ja-cjk",
+      title: "日本語検索サンプル",
+      body: "データベース最適化にはインデックス設計とトランザクション管理が必要です",
+      displayPath: "cjk/ja.md",
+    });
+    await insertTestDocument(store.db, collectionName, {
+      name: "ko-cjk",
+      title: "한국어 검색 샘플",
+      body: "데이터베이스성능최적화에는인덱스설계와트랜잭션관리가필요합니다",
+      displayPath: "cjk/ko.md",
+    });
+
+    const zh = store.searchFTS("索引", 10);
+    expect(zh.some(r => r.displayPath === `${collectionName}/cjk/zh.md`)).toBe(true);
+
+    const ja = store.searchFTS("トランザクション", 10);
+    expect(ja.some(r => r.displayPath === `${collectionName}/cjk/ja.md`)).toBe(true);
+
+    const ko = store.searchFTS("트랜잭션", 10);
+    expect(ko.some(r => r.displayPath === `${collectionName}/cjk/ko.md`)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
   // BM25 IDF requires corpus depth — helper adds non-matching docs so term frequency
   // differentiation produces meaningful scores (2-doc corpus has near-zero IDF).
   async function addNoiseDocuments(db: Database, collectionName: string, count = 8) {


### PR DESCRIPTION
## Linked Issue

Fixes #20

## Summary

This PR fixes BM25 behavior for contiguous Chinese/Japanese/Korean text in the FTS path. We now normalize CJK text at both index and query time using `Intl.Segmenter` and emit CJK bigrams for long unbroken spans so mid-sentence keywords match reliably. The same normalization is used in trigger-time indexing and lex query parsing, keeping behavior consistent across CLI and MCP search. The database initializer now includes a one-time FTS backfill migration for existing indexes and a legacy-schema guard for older `documents_fts` layouts used in tests/runtime edge cases.

## Scope Boundaries

This change does not alter vector search, reranking logic, or public CLI flags. It focuses only on BM25/FTS tokenization behavior and regression coverage for CJK keyword retrieval.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD change

## Testing Evidence

- [x] `npm run build`
- [x] `npm test`
- [x] Focused test(s): `npm test -- --run specs/store.test.ts specs/mcp.test.ts`
- [x] Manual verification:

```bash
node <<'NODE'
const Database=require('better-sqlite3');
const db=new Database(':memory:');
db.exec("CREATE VIRTUAL TABLE f USING fts5(body, tokenize='porter unicode61')");
db.prepare('INSERT INTO f(body) VALUES (?)').run('数据库性能优化需要索引设计和事务管理');
db.exec("CREATE VIRTUAL TABLE vocab USING fts5vocab(f, 'row')");
console.log(db.prepare('SELECT term FROM vocab').all());
NODE
```

Also validated end-to-end in repo tests with contiguous CJK content in:
- `specs/store.test.ts` (Chinese/Japanese/Korean mid-sentence keyword retrieval)
- `specs/mcp.test.ts` (real `createStore` indexing parity in MCP result shaping path)

## Risk / Rollback

Risk is limited to BM25 tokenization behavior. If any regression appears, rollback is straightforward by reverting this PR; no data model or API contract changes are required.

## Docs Impact

README now notes that BM25 CJK normalization is applied at index/query time.

## Release Note Impact

Improved BM25 keyword relevance for contiguous CJK text (Chinese/Japanese/Korean) in `kindx search` and MCP BM25 search.

## Reviewer Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have documented any non-obvious code paths or intentionally omitted them because the code is already clear
- [x] I updated the relevant docs, or documented why no doc changes is required
- [x] I called out scope boundaries, risk, and rollout considerations above
- [x] I added or updated tests that prove the change works
- [x] New and existing tests pass locally, or I documented the known test limitation above
- [x] My commit messages follow the Conventional Commits format
- [x] This PR is linked to an issue (`Fixes #N`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced keyword search with CJK-aware normalization for contiguous Chinese, Japanese, and Korean text, including bigram support for better matching.

* **Tests**
  * Added comprehensive tests for CJK language search functionality across real indexing and query paths.

* **Documentation**
  * Updated README describing CJK normalization improvements in keyword search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->