### PR TITLE
feat(engine): add chunk-hash incremental embedding delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,12 +564,14 @@ collections:
 ### Vector Index Generation
 
 ```bash
-# Embed all indexed documents (900 tokens/chunk, 15% overlap)
+# Embed changed/new chunks only (900 tokens/chunk, 15% overlap)
 kindx embed
 
 # Force re-embed entire corpus
 kindx embed -f
 ```
+
+`kindx embed` performs chunk-level incremental embedding. Progress is reported as `N changed / M total chunks`, and unchanged chunks are reused when possible.
 
 ### Context Management
 
@@ -745,6 +747,7 @@ erDiagram
         text hash FK
         integer seq
         integer pos
+        text chunk_hash
         blob embedding
     }
     vectors_vec {

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -24,11 +24,16 @@ import {
   isDocid,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
-  getHashesForEmbedding,
+  getDocumentsForEmbedding,
+  getExistingEmbeddingChunksForHash,
+  updateEmbeddingChunkMetadata,
+  deleteEmbeddingsForHashSeqs,
+  findReusableEmbeddingByChunkHash,
   clearAllEmbeddings,
   insertEmbedding,
   getStatus,
   hashContent,
+  hashChunkContent,
   extractTitle,
   formatDocForEmbedding,
   chunkDocumentByTokens,
@@ -1553,162 +1558,212 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
     clearAllEmbeddings(db);
   }
 
-  // Find unique hashes that need embedding (from active documents)
-  const hashesToEmbed = getHashesForEmbedding(db);
-
-  if (hashesToEmbed.length === 0) {
-    console.log(`${c.green}✓ All content hashes already have embeddings.${c.reset}`);
+  const docsForEmbedding = getDocumentsForEmbedding(db);
+  if (docsForEmbedding.length === 0) {
+    console.log(`${c.green}✓ No active documents to embed.${c.reset}`);
     closeDb();
     return;
   }
 
-  // Prepare documents with chunks
-  type ChunkItem = { hash: string; title: string; text: string; seq: number; pos: number; tokens: number; bytes: number; displayName: string };
-  const allChunks: ChunkItem[] = [];
+  type ChunkCandidate = {
+    hash: string;
+    title: string;
+    text: string;
+    seq: number;
+    pos: number;
+    tokens: number;
+    bytes: number;
+    displayName: string;
+    chunkHash: string;
+  };
+
+  const encoder = new TextEncoder();
+  const changedChunks: ChunkCandidate[] = [];
+  let totalChunks = 0;
   let multiChunkDocs = 0;
+  let staleDeleted = 0;
 
-  // Chunk all documents using actual token counts
-  process.stderr.write(`Chunking ${hashesToEmbed.length} documents by token count...\n`);
-  for (const item of hashesToEmbed) {
-    const encoder = new TextEncoder();
+  process.stderr.write(`Chunking ${docsForEmbedding.length} documents by token count...\n`);
+
+  for (const item of docsForEmbedding) {
     const bodyBytes = encoder.encode(item.body).length;
-    if (bodyBytes === 0) continue; // Skip empty
+    if (bodyBytes === 0) continue;
 
-    const title = extractTitle(item.body, item.path);
-    const displayName = item.path;
-    const chunks = await chunkDocumentByTokens(item.body);  // Uses actual tokenizer
-
+    const title = item.title || extractTitle(item.body, item.path);
+    const chunks = await chunkDocumentByTokens(item.body);
+    const existing = getExistingEmbeddingChunksForHash(db, item.hash);
+    const existingBySeq = new Map(existing.map((row) => [row.seq, row]));
+    const keepSeqs = new Set<number>();
     if (chunks.length > 1) multiChunkDocs++;
 
     for (let seq = 0; seq < chunks.length; seq++) {
-      allChunks.push({
+      const chunk = chunks[seq]!;
+      keepSeqs.add(seq);
+      totalChunks++;
+      const chunkHash = hashChunkContent(chunk.text);
+      const existingChunk = existingBySeq.get(seq);
+
+      if (existingChunk && existingChunk.chunkHash === chunkHash) {
+        if (existingChunk.pos !== chunk.pos) {
+          updateEmbeddingChunkMetadata(db, item.hash, seq, chunk.pos, chunkHash);
+        }
+        continue;
+      }
+
+      changedChunks.push({
         hash: item.hash,
         title,
-        text: chunks[seq]!.text, // Chunk is guaranteed to exist by seq loop
+        text: chunk.text,
         seq,
-        pos: chunks[seq]!.pos,
-        tokens: chunks[seq]!.tokens,
-        bytes: encoder.encode(chunks[seq]!.text).length,
-        displayName,
+        pos: chunk.pos,
+        tokens: chunk.tokens,
+        bytes: encoder.encode(chunk.text).length,
+        displayName: item.path,
+        chunkHash,
       });
+    }
+
+    const staleSeqs = existing
+      .map((row) => row.seq)
+      .filter((seq) => !keepSeqs.has(seq));
+    if (staleSeqs.length > 0) {
+      staleDeleted += deleteEmbeddingsForHashSeqs(db, item.hash, staleSeqs);
     }
   }
 
-  if (allChunks.length === 0) {
-    console.log(`${c.green}✓ No non-empty documents to embed.${c.reset}`);
+  const changedChunkCount = changedChunks.length;
+  if (changedChunkCount === 0) {
+    if (staleDeleted > 0) {
+      console.log(`${c.green}✓ No changed chunks. Removed ${staleDeleted} stale chunk embeddings.${c.reset}`);
+    } else {
+      console.log(`${c.green}✓ No changed chunks. 0/${totalChunks} need embedding.${c.reset}`);
+    }
     closeDb();
     return;
   }
 
-  const totalBytes = allChunks.reduce((sum, chk) => sum + chk.bytes, 0);
-  const totalChunks = allChunks.length;
-  const totalDocs = hashesToEmbed.length;
-
-  console.log(`${c.bold}Embedding ${totalDocs} documents${c.reset} ${c.dim}(${totalChunks} chunks, ${formatBytes(totalBytes)})${c.reset}`);
+  const totalChangedBytes = changedChunks.reduce((sum, chunk) => sum + chunk.bytes, 0);
+  const totalDocs = docsForEmbedding.length;
+  console.log(`${c.bold}Embedding delta for ${totalDocs} documents${c.reset} ${c.dim}(${changedChunkCount} changed / ${totalChunks} total chunks, ${formatBytes(totalChangedBytes)})${c.reset}`);
   if (multiChunkDocs > 0) {
     console.log(`${c.dim}${multiChunkDocs} documents split into multiple chunks${c.reset}`);
   }
   console.log(`${c.dim}Model: ${model}${c.reset}\n`);
 
+  let chunksReused = 0;
+  let errors = 0;
+  let bytesProcessed = 0;
+  const chunksToEmbed: ChunkCandidate[] = [];
+
+  for (const chunk of changedChunks) {
+    const reusable = findReusableEmbeddingByChunkHash(db, chunk.chunkHash, model);
+    if (reusable?.embedding) {
+      const source = reusable.embedding;
+      const view = new Float32Array(source.buffer, source.byteOffset, Math.floor(source.byteLength / Float32Array.BYTES_PER_ELEMENT));
+      const copied = new Float32Array(view);
+      insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, copied, model, now, chunk.chunkHash);
+      chunksReused++;
+      bytesProcessed += chunk.bytes;
+    } else {
+      chunksToEmbed.push(chunk);
+    }
+  }
+
   // Hide cursor during embedding
   cursor.hide();
 
-  // Wrap all LLM embedding operations in a session for lifecycle management
-  // Use 30 minute timeout for large collections
-  await withLLMSession(async (session) => {
-    // Get embedding dimensions from first chunk
-    progress.indeterminate();
-    const firstChunk = allChunks[0];
-    if (!firstChunk) {
-      throw new Error("No chunks available to embed");
-    }
-    const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
-    const firstResult = await session.embed(firstText);
-    if (!firstResult) {
-      throw new Error("Failed to get embedding dimensions from first chunk");
-    }
-    ensureVecTable(db, firstResult.embedding.length);
+  if (chunksToEmbed.length > 0) {
+    await withLLMSession(async (session) => {
+      progress.indeterminate();
+      const firstChunk = chunksToEmbed[0];
+      if (!firstChunk) {
+        throw new Error("No chunks available to embed");
+      }
+      const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
+      const firstResult = await session.embed(firstText);
+      if (!firstResult) {
+        throw new Error("Failed to get embedding dimensions from first chunk");
+      }
+      ensureVecTable(db, firstResult.embedding.length);
 
-    let chunksEmbedded = 0, errors = 0, bytesProcessed = 0;
-    const startTime = Date.now();
+      const startTime = Date.now();
+      const BATCH_SIZE = 32;
+      let chunksEmbedded = 0;
 
-    // Batch embedding for better throughput
-    // Process in batches of 32 to balance memory usage and efficiency
-    const BATCH_SIZE = 32;
+      for (let batchStart = 0; batchStart < chunksToEmbed.length; batchStart += BATCH_SIZE) {
+        const batchEnd = Math.min(batchStart + BATCH_SIZE, chunksToEmbed.length);
+        const batch = chunksToEmbed.slice(batchStart, batchEnd);
+        const texts = batch.map((chunk) => formatDocForEmbedding(chunk.text, chunk.title));
 
-    for (let batchStart = 0; batchStart < allChunks.length; batchStart += BATCH_SIZE) {
-      const batchEnd = Math.min(batchStart + BATCH_SIZE, allChunks.length);
-      const batch = allChunks.slice(batchStart, batchEnd);
-
-      // Format texts for embedding
-      const texts = batch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title));
-
-      try {
-        // Batch embed all texts at once
-        const embeddings = await session.embedBatch(texts);
-
-        // Insert each embedding
-        for (let i = 0; i < batch.length; i++) {
-          const chunk = batch[i]!;
-          const embedding = embeddings[i];
-
-          if (embedding) {
-            insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(embedding.embedding), model, now);
-            chunksEmbedded++;
-          } else {
-            errors++;
-            console.error(`\n${c.yellow}⚠ Error embedding "${chunk.displayName}" chunk ${chunk.seq}${c.reset}`);
-          }
-          bytesProcessed += chunk.bytes;
-        }
-      } catch (err) {
-        // If batch fails, try individual embeddings as fallback
-        for (const chunk of batch) {
-          try {
-            const text = formatDocForEmbedding(chunk.text, chunk.title);
-            const result = await session.embed(text);
-            if (result) {
-              insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
+        try {
+          const embeddings = await session.embedBatch(texts);
+          for (let i = 0; i < batch.length; i++) {
+            const chunk = batch[i]!;
+            const embedding = embeddings[i];
+            if (embedding) {
+              insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(embedding.embedding), model, now, chunk.chunkHash);
               chunksEmbedded++;
             } else {
               errors++;
+              console.error(`\n${c.yellow}⚠ Error embedding "${chunk.displayName}" chunk ${chunk.seq}${c.reset}`);
             }
-          } catch (innerErr) {
-            errors++;
-            console.error(`\n${c.yellow}⚠ Error embedding "${chunk.displayName}" chunk ${chunk.seq}: ${innerErr}${c.reset}`);
+            bytesProcessed += chunk.bytes;
           }
-          bytesProcessed += chunk.bytes;
+        } catch (err) {
+          for (const chunk of batch) {
+            try {
+              const text = formatDocForEmbedding(chunk.text, chunk.title);
+              const result = await session.embed(text);
+              if (result) {
+                insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now, chunk.chunkHash);
+                chunksEmbedded++;
+              } else {
+                errors++;
+              }
+            } catch (innerErr) {
+              errors++;
+              console.error(`\n${c.yellow}⚠ Error embedding "${chunk.displayName}" chunk ${chunk.seq}: ${innerErr}${c.reset}`);
+            }
+            bytesProcessed += chunk.bytes;
+          }
         }
+
+        const percent = totalChangedBytes > 0 ? (bytesProcessed / totalChangedBytes) * 100 : 100;
+        progress.set(percent);
+        const elapsed = (Date.now() - startTime) / 1000;
+        const bytesPerSec = bytesProcessed / Math.max(elapsed, 0.001);
+        const remainingBytes = Math.max(0, totalChangedBytes - bytesProcessed);
+        const etaSec = remainingBytes / Math.max(bytesPerSec, 1);
+        const bar = renderProgressBar(percent);
+        const percentStr = percent.toFixed(0).padStart(3);
+        const throughput = `${formatBytes(bytesPerSec)}/s`;
+        const eta = elapsed > 2 ? formatETA(etaSec) : "...";
+        const errStr = errors > 0 ? ` ${c.yellow}${errors} err${c.reset}` : "";
+        if (isTTY) process.stderr.write(`\r${c.cyan}${bar}${c.reset} ${c.bold}${percentStr}%${c.reset} ${c.dim}${bytesProcessed > 0 ? Math.min(chunksEmbedded + chunksReused, changedChunkCount) : chunksReused}/${changedChunkCount}${c.reset}${errStr} ${c.dim}${throughput} ETA ${eta}${c.reset}   `);
       }
 
-      const percent = (bytesProcessed / totalBytes) * 100;
-      progress.set(percent);
-
-      const elapsed = (Date.now() - startTime) / 1000;
-      const bytesPerSec = bytesProcessed / elapsed;
-      const remainingBytes = totalBytes - bytesProcessed;
-      const etaSec = remainingBytes / bytesPerSec;
-
-      const bar = renderProgressBar(percent);
-      const percentStr = percent.toFixed(0).padStart(3);
-      const throughput = `${formatBytes(bytesPerSec)}/s`;
-      const eta = elapsed > 2 ? formatETA(etaSec) : "...";
-      const errStr = errors > 0 ? ` ${c.yellow}${errors} err${c.reset}` : "";
-
-      if (isTTY) process.stderr.write(`\r${c.cyan}${bar}${c.reset} ${c.bold}${percentStr}%${c.reset} ${c.dim}${chunksEmbedded}/${totalChunks}${c.reset}${errStr} ${c.dim}${throughput} ETA ${eta}${c.reset}   `);
-    }
-
+      progress.clear();
+      cursor.show();
+      const totalTimeSec = (Date.now() - startTime) / 1000;
+      const avgThroughput = formatBytes(totalChangedBytes / Math.max(totalTimeSec, 0.001));
+      console.log(`\r${c.green}${renderProgressBar(100)}${c.reset} ${c.bold}100%${c.reset}                                    `);
+      console.log(`\n${c.green}✓ Done!${c.reset} Processed ${c.bold}${changedChunkCount}${c.reset} changed chunks (${c.bold}${chunksEmbedded}${c.reset} embedded, ${c.bold}${chunksReused}${c.reset} reused) out of ${c.bold}${totalChunks}${c.reset} total in ${c.bold}${formatETA(totalTimeSec)}${c.reset} ${c.dim}(${avgThroughput}/s)${c.reset}`);
+      if (staleDeleted > 0) {
+        console.log(`${c.dim}Removed ${staleDeleted} stale chunk embeddings${c.reset}`);
+      }
+      if (errors > 0) {
+        console.log(`${c.yellow}⚠ ${errors} chunks failed${c.reset}`);
+      }
+    }, { maxDuration: 30 * 60 * 1000, name: 'embed-command' });
+  } else {
     progress.clear();
     cursor.show();
-    const totalTimeSec = (Date.now() - startTime) / 1000;
-    const avgThroughput = formatBytes(totalBytes / totalTimeSec);
-
     console.log(`\r${c.green}${renderProgressBar(100)}${c.reset} ${c.bold}100%${c.reset}                                    `);
-    console.log(`\n${c.green}✓ Done!${c.reset} Embedded ${c.bold}${chunksEmbedded}${c.reset} chunks from ${c.bold}${totalDocs}${c.reset} documents in ${c.bold}${formatETA(totalTimeSec)}${c.reset} ${c.dim}(${avgThroughput}/s)${c.reset}`);
-    if (errors > 0) {
-      console.log(`${c.yellow}⚠ ${errors} chunks failed${c.reset}`);
+    console.log(`\n${c.green}✓ Done!${c.reset} Processed ${c.bold}${changedChunkCount}${c.reset} changed chunks (${c.bold}${chunksReused}${c.reset} reused, ${c.bold}0${c.reset} embedded) out of ${c.bold}${totalChunks}${c.reset} total.`);
+    if (staleDeleted > 0) {
+      console.log(`${c.dim}Removed ${staleDeleted} stale chunk embeddings${c.reset}`);
     }
-  }, { maxDuration: 30 * 60 * 1000, name: 'embed-command' });
+  }
 
   closeDb();
 }

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -168,6 +168,10 @@ export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boole
   return fences.some(f => pos > f.start && pos < f.end);
 }
 
+function isHeadingBreakPoint(bp: BreakPoint): boolean {
+  return /^h[1-6]$/.test(bp.type);
+}
+
 /**
  * Find the best cut position using scored break points with distance decay.
  *
@@ -189,8 +193,10 @@ export function findBestCutoff(
   codeFences: CodeFenceRegion[] = []
 ): number {
   const windowStart = targetCharPos - windowChars;
-  let bestScore = -1;
-  let bestPos = targetCharPos;
+  let bestHeadingScore = -1;
+  let bestHeadingPos = targetCharPos;
+  let bestFallbackScore = -1;
+  let bestFallbackPos = targetCharPos;
 
   for (const bp of breakPoints) {
     if (bp.pos < windowStart) continue;
@@ -210,13 +216,22 @@ export function findBestCutoff(
     const multiplier = 1.0 - (normalizedDist * normalizedDist) * decayFactor;
     const finalScore = bp.score * multiplier;
 
-    if (finalScore > bestScore) {
-      bestScore = finalScore;
-      bestPos = bp.pos;
+    if (isHeadingBreakPoint(bp) && bp.score >= 30 && finalScore > bestHeadingScore) {
+      bestHeadingScore = finalScore;
+      bestHeadingPos = bp.pos;
+      continue;
+    }
+    if (finalScore > bestFallbackScore) {
+      bestFallbackScore = finalScore;
+      bestFallbackPos = bp.pos;
     }
   }
 
-  return bestPos;
+  // Prefer heading boundaries for positional stability; fallback to normal scoring otherwise.
+  if (bestHeadingScore >= 0) {
+    return bestHeadingPos;
+  }
+  return bestFallbackPos;
 }
 
 // Hybrid query: strong BM25 signal detection thresholds
@@ -803,6 +818,7 @@ function initializeDatabase(db: Database): void {
   // Content vectors
   const cvInfo = db.prepare(`PRAGMA table_info(content_vectors)`).all() as { name: string }[];
   const hasSeqColumn = cvInfo.some(col => col.name === 'seq');
+  const hasChunkHashColumn = cvInfo.some(col => col.name === 'chunk_hash');
   if (cvInfo.length > 0 && !hasSeqColumn) {
     db.exec(`DROP TABLE IF EXISTS content_vectors`);
     db.exec(`DROP TABLE IF EXISTS vectors_vec`);
@@ -814,9 +830,13 @@ function initializeDatabase(db: Database): void {
       pos INTEGER NOT NULL DEFAULT 0,
       model TEXT NOT NULL,
       embedded_at TEXT NOT NULL,
+      chunk_hash TEXT,
       PRIMARY KEY (hash, seq)
     )
   `);
+  if (cvInfo.length > 0 && !hasChunkHashColumn) {
+    db.exec(`ALTER TABLE content_vectors ADD COLUMN chunk_hash TEXT`);
+  }
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS feedback (
@@ -1236,6 +1256,20 @@ export type SearchResult = DocumentResult & {
   chunkPos?: number;          // Character position of matching chunk (for vector search)
 };
 
+export type EmbeddingDocument = {
+  hash: string;
+  body: string;
+  path: string;
+  title: string;
+};
+
+export type ExistingEmbeddingChunk = {
+  seq: number;
+  pos: number;
+  chunkHash: string | null;
+  model: string;
+};
+
 /**
  * Ranked result for RRF fusion (simplified, used internally)
  */
@@ -1483,6 +1517,12 @@ export function vacuumDatabase(db: Database): void {
 // =============================================================================
 
 export async function hashContent(content: string): Promise<string> {
+  const hash = createHash("sha256");
+  hash.update(content);
+  return hash.digest("hex");
+}
+
+export function hashChunkContent(content: string): string {
   const hash = createHash("sha256");
   hash.update(content);
   return hash.digest("hex");
@@ -2563,6 +2603,75 @@ export function getHashesForEmbedding(db: Database): { hash: string; body: strin
   `).all() as { hash: string; body: string; path: string }[];
 }
 
+export function getDocumentsForEmbedding(db: Database): EmbeddingDocument[] {
+  return db.prepare(`
+    SELECT d.hash, c.doc as body, MIN(d.path) as path, MIN(d.title) as title
+    FROM documents d
+    JOIN content c ON d.hash = c.hash
+    WHERE d.active = 1
+    GROUP BY d.hash
+  `).all() as EmbeddingDocument[];
+}
+
+export function getExistingEmbeddingChunksForHash(db: Database, hash: string): ExistingEmbeddingChunk[] {
+  return db.prepare(`
+    SELECT seq, pos, chunk_hash as chunkHash, model
+    FROM content_vectors
+    WHERE hash = ?
+    ORDER BY seq
+  `).all(hash) as ExistingEmbeddingChunk[];
+}
+
+export function updateEmbeddingChunkMetadata(
+  db: Database,
+  hash: string,
+  seq: number,
+  pos: number,
+  chunkHash: string
+): void {
+  db.prepare(`
+    UPDATE content_vectors
+    SET pos = ?, chunk_hash = ?
+    WHERE hash = ? AND seq = ?
+  `).run(pos, chunkHash, hash, seq);
+}
+
+export function deleteEmbeddingsForHashSeqs(db: Database, hash: string, seqs: number[]): number {
+  if (seqs.length === 0) return 0;
+
+  const vecPlaceholders = seqs.map(() => '?').join(',');
+  const seqPlaceholders = seqs.map(() => '?').join(',');
+  const hashSeqs = seqs.map(seq => `${hash}_${seq}`);
+
+  db.prepare(`DELETE FROM vectors_vec WHERE hash_seq IN (${vecPlaceholders})`).run(...hashSeqs);
+  const result = db.prepare(`
+    DELETE FROM content_vectors
+    WHERE hash = ? AND seq IN (${seqPlaceholders})
+  `).run(hash, ...seqs);
+  return result.changes;
+}
+
+export function findReusableEmbeddingByChunkHash(
+  db: Database,
+  chunkHash: string,
+  model: string
+): { embedding: Buffer; sourceHashSeq: string } | null {
+  const tableExists = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'
+  `).get();
+  if (!tableExists) {
+    return null;
+  }
+  const row = db.prepare(`
+    SELECT vv.hash_seq as sourceHashSeq, vv.embedding
+    FROM content_vectors cv
+    JOIN vectors_vec vv ON vv.hash_seq = cv.hash || '_' || cv.seq
+    WHERE cv.chunk_hash = ? AND cv.model = ?
+    LIMIT 1
+  `).get(chunkHash, model) as { sourceHashSeq: string; embedding: Buffer } | undefined;
+  return row ?? null;
+}
+
 /**
  * Clear all embeddings from the database (force re-index).
  * Deletes all rows from content_vectors and drops the vectors_vec table.
@@ -2583,14 +2692,18 @@ export function insertEmbedding(
   pos: number,
   embedding: Float32Array,
   model: string,
-  embeddedAt: string
+  embeddedAt: string,
+  chunkHash?: string
 ): void {
   const hashSeq = `${hash}_${seq}`;
   const insertVecStmt = db.prepare(`INSERT OR REPLACE INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`);
-  const insertContentVectorStmt = db.prepare(`INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, ?, ?, ?, ?)`);
+  const insertContentVectorStmt = db.prepare(`
+    INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embedded_at, chunk_hash)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
 
   insertVecStmt.run(hashSeq, embedding);
-  insertContentVectorStmt.run(hash, seq, pos, model, embeddedAt);
+  insertContentVectorStmt.run(hash, seq, pos, model, embeddedAt, chunkHash ?? null);
 }
 
 // =============================================================================

--- a/specs/store.test.ts
+++ b/specs/store.test.ts
@@ -24,6 +24,7 @@ import {
   getPwd,
   getRealPath,
   hashContent,
+  hashChunkContent,
   extractTitle,
   formatQueryForEmbedding,
   formatDocForEmbedding,
@@ -33,6 +34,12 @@ import {
   findCodeFences,
   isInsideCodeFence,
   findBestCutoff,
+  getDocumentsForEmbedding,
+  getExistingEmbeddingChunksForHash,
+  updateEmbeddingChunkMetadata,
+  deleteEmbeddingsForHashSeqs,
+  findReusableEmbeddingByChunkHash,
+  insertEmbedding,
   type BreakPoint,
   type CodeFenceRegion,
   reciprocalRankFusion,
@@ -893,6 +900,15 @@ describe("findBestCutoff", () => {
     // newline at 195: dist=5, mult=0.998, final=0.998
     const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7);
     expect(cutoff).toBe(150); // h1 wins easily
+  });
+
+  test("prefers heading breakpoints over non-heading breaks for stability", () => {
+    const breakPoints: BreakPoint[] = [
+      { pos: 130, score: 50, type: "h6" },
+      { pos: 198, score: 60, type: "hr" },
+    ];
+    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7);
+    expect(cutoff).toBe(130);
   });
 
   test("returns target position when no breaks in window", () => {
@@ -2282,6 +2298,105 @@ describe("Integration", () => {
 
     await cleanupTestDb(store1);
     await cleanupTestDb(store2);
+  });
+});
+
+describe("Embedding Delta Utilities", () => {
+  test("schema includes chunk_hash in content_vectors", async () => {
+    const store = await createTestStore();
+    const tableInfo = store.db.prepare(`PRAGMA table_info(content_vectors)`).all() as { name: string }[];
+    const columnNames = tableInfo.map((col) => col.name);
+    expect(columnNames).toContain("chunk_hash");
+    await cleanupTestDb(store);
+  });
+
+  test("hashChunkContent is stable and content-sensitive", () => {
+    const a = hashChunkContent("hello world");
+    const b = hashChunkContent("hello world");
+    const c = hashChunkContent("hello world!");
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  test("embedding chunk metadata helpers support update and deletion", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    const hash = "delta_hash_1";
+    await insertTestDocument(store.db, collectionName, {
+      name: "delta",
+      hash,
+      body: "delta body",
+      filepath: "/test/delta.md",
+      displayPath: "delta.md",
+    });
+
+    store.ensureVecTable(8);
+    insertEmbedding(store.db, hash, 0, 0, new Float32Array(8).fill(0.1), "embeddinggemma", new Date().toISOString(), "h0");
+    insertEmbedding(store.db, hash, 1, 10, new Float32Array(8).fill(0.2), "embeddinggemma", new Date().toISOString(), "h1");
+
+    let rows = getExistingEmbeddingChunksForHash(store.db, hash);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.chunkHash).toBe("h0");
+    expect(rows[1]!.chunkHash).toBe("h1");
+
+    updateEmbeddingChunkMetadata(store.db, hash, 1, 12, "h1-updated");
+    rows = getExistingEmbeddingChunksForHash(store.db, hash);
+    expect(rows[1]!.pos).toBe(12);
+    expect(rows[1]!.chunkHash).toBe("h1-updated");
+
+    const deleted = deleteEmbeddingsForHashSeqs(store.db, hash, [0]);
+    expect(deleted).toBe(1);
+    rows = getExistingEmbeddingChunksForHash(store.db, hash);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.seq).toBe(1);
+
+    await cleanupTestDb(store);
+  });
+
+  test("findReusableEmbeddingByChunkHash returns reusable vector rows by model", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    const hash = "reuse_hash_1";
+    await insertTestDocument(store.db, collectionName, {
+      name: "reuse",
+      hash,
+      body: "reuse body",
+      filepath: "/test/reuse.md",
+      displayPath: "reuse.md",
+    });
+
+    store.ensureVecTable(8);
+    insertEmbedding(store.db, hash, 0, 0, new Float32Array(8).fill(0.5), "embeddinggemma", new Date().toISOString(), "shared_chunk_hash");
+
+    const reusable = findReusableEmbeddingByChunkHash(store.db, "shared_chunk_hash", "embeddinggemma");
+    expect(reusable).not.toBeNull();
+    expect(reusable?.sourceHashSeq).toBe(`${hash}_0`);
+    expect(reusable?.embedding.byteLength).toBeGreaterThan(0);
+
+    const missingModel = findReusableEmbeddingByChunkHash(store.db, "shared_chunk_hash", "other-model");
+    expect(missingModel).toBeNull();
+
+    await cleanupTestDb(store);
+  });
+
+  test("getDocumentsForEmbedding returns active document payloads", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+    const createdAt = new Date().toISOString();
+    const hash = await hashContent("doc body");
+    store.insertContent(hash, "doc body", createdAt);
+    store.insertDocument(collectionName, "active.md", "Active", hash, createdAt, createdAt);
+    store.deactivateDocument(collectionName, "active.md");
+    store.insertDocument(collectionName, "active-2.md", "Active 2", hash, createdAt, createdAt);
+
+    const docs = getDocumentsForEmbedding(store.db);
+    expect(docs).toHaveLength(1);
+    expect(docs[0]!.hash).toBe(hash);
+    expect(docs[0]!.path).toBe("active-2.md");
+
+    await cleanupTestDb(store);
   });
 });
 


### PR DESCRIPTION
## Linked Issue

Fixes #21

## Summary

This PR implements chunk-level incremental embedding for `kindx embed` using a new `content_vectors.chunk_hash` column and delta planning based on current chunk hashes. Instead of embedding every chunk for a newly changed content hash, the embed flow now computes changed chunks, reuses matching chunk vectors when possible, and only calls embedding APIs for chunks that are truly new/changed. It also removes stale chunk rows when chunk counts shrink and reports progress as `changed / total chunks`.

Chunk boundary selection is also updated to prefer heading breakpoints (score >= 30) before fallback breakpoints, improving positional stability for section edits.

## Scope Boundaries

This PR is intentionally limited to incremental embedding behavior, chunk metadata schema evolution, related tests, and README updates for embed behavior. It does not change query ranking logic, MCP tool shapes, or remote API contract behavior outside normal embed execution.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [x] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD change

## Testing Evidence

- [x] `npm run build`
- [x] `npm test`
- [x] Focused test(s):
  - `npx vitest run --reporter=verbose specs/store.test.ts`
  - `npx vitest run --reporter=verbose specs/command-line.test.ts -t "migrates documents from Chroma|runs embed and query completely through remote API"`
- [x] Manual verification:
  - Reproduced migration + embed flow from CLI (`kindx migrate chroma ...` then `kindx embed`) and confirmed successful embed execution after delta/reuse guard fixes.

## Risk / Rollback

Primary risk is regression in embedding bookkeeping for mixed legacy/new indexes. Mitigations include schema-compat migration (`ALTER TABLE ... chunk_hash`) and dedicated tests for metadata updates/reuse/deletion. Rollback is straightforward by reverting this PR commit; existing data remains readable because the new column is additive.

## Docs Impact

README embed section now documents chunk-level incremental behavior and `changed / total chunks` reporting, and the schema block includes `chunk_hash`.

## Release Note Impact

`kindx embed` now performs chunk-hash delta embedding with reuse of unchanged chunks and reports changed chunk counts.

## Reviewer Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have documented any non-obvious code paths or intentionally omitted them because the code is already clear
- [x] I updated the relevant docs, or documented why no docs change is required
- [x] I called out scope boundaries, risk, and rollout considerations above
- [x] I added or updated tests that prove the change works
- [x] New and existing tests pass locally, or I documented the known test limitation above
- [x] My commit messages follow the Conventional Commits format
- [x] This PR is linked to an issue (`Fixes #N`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented chunk-level incremental embedding—only modified chunks are re-embedded while unchanged chunks are reused.
  * Enhanced progress reporting to display detailed metrics showing changed chunks relative to total chunks.

* **Documentation**
  * Updated storage documentation to describe the new chunk-level incremental embedding approach.

* **Tests**
  * Added comprehensive test coverage for embedding delta utilities and chunk-level embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->