### PR TITLE
feat(engine): implement semantic query cache for expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,8 +771,8 @@ erDiagram
         integer hits
     }
     semantic_cache_vec {
-        integer cache_id PK
-        blob embedding
+        text cache_key PK
+        float[768] embedding
     }
 
     collections ||--o{ documents : contains

--- a/README.md
+++ b/README.md
@@ -461,7 +461,8 @@ kindx pull                   # Download/check the default local models
 kindx update                 # Re-index configured collections
 kindx watch                  # Keep the index fresh in the background
 kindx status                 # Report index, collection, and MCP health
-kindx cleanup                # Clear cache/orphaned rows and vacuum the DB
+kindx cleanup                # Clear caches, orphaned rows, and vacuum the DB
+kindx cleanup --cache        # Clear only LLM + semantic query caches
 kindx mcp                    # Start the MCP server (stdio by default)
 kindx migrate <target> <path> # Import from Chroma or OpenCLAW
 kindx skill install          # Install the packaged Claude skill locally
@@ -692,8 +693,11 @@ kindx multi-get "docs/*.md" --max-bytes 20480
 # Export bulk extraction as JSON for agent processing
 kindx multi-get "docs/*.md" --json
 
-# Purge cache and orphaned index data
+# Purge caches + orphaned index data
 kindx cleanup
+
+# Purge only LLM + semantic caches
+kindx cleanup --cache
 
 # Import an existing Chroma or OpenCLAW corpus
 kindx migrate chroma /path/to/chroma.sqlite3
@@ -759,11 +763,23 @@ erDiagram
         text response
         integer created
     }
+    semantic_cache {
+        integer id PK
+        text query
+        text response
+        text created_at
+        integer hits
+    }
+    semantic_cache_vec {
+        integer cache_id PK
+        blob embedding
+    }
 
     collections ||--o{ documents : contains
     documents ||--|{ documents_fts : indexes
     documents ||--o{ content_vectors : chunks
     content_vectors ||--|| vectors_vec : embeds
+    semantic_cache ||--|| semantic_cache_vec : embeds
 ```
 
 ---
@@ -783,6 +799,8 @@ erDiagram
 | `KINDX_LOW_VRAM_EXPAND_CONTEXT_SIZE` | `1024` | Expansion context size cap in low-VRAM mode |
 | `KINDX_LOW_VRAM_RERANK_CONTEXT_SIZE` | `1024` | Rerank context size cap in low-VRAM mode |
 | `KINDX_CONFIG_DIR` | `~/.config/kindx` | Configuration directory override |
+| `KINDX_SEMANTIC_CACHE_THRESHOLD` | `0.92` | Minimum cosine similarity to reuse semantic query-expansion cache |
+| `KINDX_CACHE_TTL_HOURS` | `168` | Semantic query-expansion cache entry TTL in hours |
 | `XDG_CACHE_HOME` | `~/.cache` | Cache base directory |
 | `NO_COLOR` | (unset) | Disable ANSI terminal colors |
 | `KINDX_LLM_BACKEND` | `local` | Set to `remote` to use an OpenAI-compatible API instead of local GPU |

--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ erDiagram
     semantic_cache {
         integer id PK
         text query
+        text model
         text response
         text created_at
         integer hits

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -59,8 +59,10 @@ import {
   getActiveDocumentPaths,
   cleanupOrphanedContent,
   deleteLLMCache,
+  deleteSemanticCache,
   deleteInactiveDocuments,
   cleanupOrphanedVectors,
+  shouldInvalidateSemanticCache,
   vacuumDatabase,
   getCollectionsWithoutContext,
   getTopLevelPathsWithoutContext,
@@ -1411,6 +1413,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   const resolvedPwd = pwd || getPwd();
   const now = new Date().toISOString();
   const excludeDirs = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
+  const activeDocsBefore = (db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number }).count;
 
   // Clear Ollama cache on index
   clearCache(db);
@@ -1527,6 +1530,13 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
 
   // Clean up orphaned content hashes (content not referenced by any document)
   const orphanedContent = cleanupOrphanedContent(db);
+  const changedCount = indexed + updated + removed;
+  if (shouldInvalidateSemanticCache(changedCount, activeDocsBefore)) {
+    const flushed = deleteSemanticCache(db);
+    if (flushed > 0) {
+      console.log(`Flushed ${flushed} semantic cache entr${flushed === 1 ? "y" : "ies"} (>10% corpus delta)`);
+    }
+  }
 
   // Check if vector index needs updating
   const needsEmbedding = getHashesNeedingEmbedding(db);
@@ -1735,6 +1745,13 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
   }
 
   let changedChunkCount = changedChunks.length;
+  const changedDocCount = new Set(changedChunks.map((chunk) => chunk.hash)).size;
+  if (shouldInvalidateSemanticCache(changedDocCount, docsForEmbedding.length)) {
+    const flushed = deleteSemanticCache(db);
+    if (flushed > 0) {
+      console.log(`Flushed ${flushed} semantic cache entr${flushed === 1 ? "y" : "ies"} (>10% corpus delta)`);
+    }
+  }
   if (changedChunkCount === 0) {
     if (staleDeleted > 0) {
       console.log(`${c.green}✓ No changed chunks. Removed ${staleDeleted} stale chunk embeddings.${c.reset}`);
@@ -2735,6 +2752,7 @@ function parseCLI() {
       daemon: { type: "boolean" },
       watch: { type: "boolean" },
       port: { type: "string" },
+      cache: { type: "boolean" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -2861,7 +2879,7 @@ function showHelp(): void {
   console.log("  kindx migrate openclaw <path>   - Migrate an OpenCLAW repository to use KINDX");
   console.log("  kindx update [--pull]           - Re-index collections (optionally git pull first)");
   console.log("  kindx embed [-f]                - Generate/refresh vector embeddings");
-  console.log("  kindx cleanup                   - Clear caches, vacuum DB");
+  console.log("  kindx cleanup [--cache]         - Full cleanup (default) or cache-only purge");
   console.log("");
   console.log("Corrective feedback:");
   console.log("  kindx feedback --irrelevant --query \"deploy k8s\" --chunk \"#abc123:2\"");
@@ -3572,10 +3590,18 @@ if (isMain) {
 
     case "cleanup": {
       const db = getDb();
+      const cacheOnly = !!cli.values.cache;
 
       // 1. Clear llm_cache
-      const cacheCount = deleteLLMCache(db);
-      console.log(`${c.green}✓${c.reset} Cleared ${cacheCount} cached API responses`);
+      const llmCacheCount = deleteLLMCache(db);
+      const semanticCacheCount = deleteSemanticCache(db);
+      console.log(`${c.green}✓${c.reset} Cleared ${llmCacheCount} cached API responses`);
+      console.log(`${c.green}✓${c.reset} Cleared ${semanticCacheCount} semantic query cache entr${semanticCacheCount === 1 ? "y" : "ies"}`);
+
+      if (cacheOnly) {
+        closeDb();
+        break;
+      }
 
       // 2. Remove orphaned vectors
       const orphanedVecs = cleanupOrphanedVectors(db);

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -502,6 +502,11 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
+type SemanticDeltaAccumulator = {
+  activeDocsBefore: number;
+  changedCount: number;
+};
+
 async function updateCollections(collectionFilter?: string | string[]): Promise<void> {
   const db = getDb();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -534,6 +539,8 @@ async function updateCollections(collectionFilter?: string | string[]): Promise<
 
   // Don't close db here - indexFiles will reuse it and close at the end
   console.log(`${c.bold}Updating ${collections.length} collection(s)...${c.reset}\n`);
+  const activeDocsBefore = (db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number }).count;
+  const semanticDelta: SemanticDeltaAccumulator = { activeDocsBefore, changedCount: 0 };
 
   for (let i = 0; i < collections.length; i++) {
     const col = collections[i];
@@ -576,12 +583,18 @@ async function updateCollections(collectionFilter?: string | string[]): Promise<
       }
     }
 
-    await indexFiles(col.pwd, col.glob_pattern, col.name, true, yamlCol?.ignore);
+    await indexFiles(col.pwd, col.glob_pattern, col.name, true, yamlCol?.ignore, semanticDelta);
     console.log("");
   }
 
   // Check if any documents need embedding (show once at end)
   const finalDb = getDb();
+  if (shouldInvalidateSemanticCache(semanticDelta.changedCount, semanticDelta.activeDocsBefore)) {
+    const flushed = deleteSemanticCache(finalDb);
+    if (flushed > 0) {
+      console.log(`Flushed ${flushed} semantic cache entr${flushed === 1 ? "y" : "ies"} (>10% corpus delta)`);
+    }
+  }
   const needsEmbedding = getHashesNeedingEmbedding(finalDb);
   closeDb();
 
@@ -1408,12 +1421,21 @@ function collectionRename(oldName: string, newName: string): void {
   console.log(`  Virtual paths updated: ${c.cyan}kindx://${oldName}/${c.reset} → ${c.cyan}kindx://${newName}/${c.reset}`);
 }
 
-async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false, ignorePatterns?: string[]): Promise<void> {
+async function indexFiles(
+  pwd?: string,
+  globPattern: string = DEFAULT_GLOB,
+  collectionName?: string,
+  suppressEmbedNotice: boolean = false,
+  ignorePatterns?: string[],
+  semanticDelta?: SemanticDeltaAccumulator
+): Promise<void> {
   const db = getDb();
   const resolvedPwd = pwd || getPwd();
   const now = new Date().toISOString();
   const excludeDirs = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
-  const activeDocsBefore = (db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number }).count;
+  const activeDocsBefore = semanticDelta
+    ? semanticDelta.activeDocsBefore
+    : (db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number }).count;
 
   // Clear Ollama cache on index
   clearCache(db);
@@ -1531,7 +1553,9 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   // Clean up orphaned content hashes (content not referenced by any document)
   const orphanedContent = cleanupOrphanedContent(db);
   const changedCount = indexed + updated + removed;
-  if (shouldInvalidateSemanticCache(changedCount, activeDocsBefore)) {
+  if (semanticDelta) {
+    semanticDelta.changedCount += changedCount;
+  } else if (shouldInvalidateSemanticCache(changedCount, activeDocsBefore)) {
     const flushed = deleteSemanticCache(db);
     if (flushed > 0) {
       console.log(`Flushed ${flushed} semantic cache entr${flushed === 1 ? "y" : "ies"} (>10% corpus delta)`);

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -1675,8 +1675,15 @@ export function deleteSemanticCache(db: Database): number {
     const semanticVecExists = db.prepare(`
       SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
     `).get();
-    if (semanticVecExists) {
+    if (_sqliteVecAvailable && semanticVecExists) {
       db.exec(`DELETE FROM semantic_cache_vec`);
+    } else if (semanticVecExists) {
+      // sqlite-vec may be unavailable in this runtime even if the table exists on disk.
+      try {
+        db.exec(`DELETE FROM semantic_cache_vec`);
+      } catch {
+        // Best-effort cleanup: keep semantic_cache purge successful.
+      }
     }
   });
   return countRow.count;
@@ -3010,8 +3017,11 @@ export async function expandQuery(
   }
 
   const semanticThreshold = getSemanticCacheThresholdValue(options.semanticThreshold);
+  const canUseSemanticCache = semanticCacheTablesAvailable(db);
   const queryEmbedding = options.queryEmbedding
-    ?? await getEmbedding(query, DEFAULT_EMBED_MODEL, true, options.session);
+    ?? (canUseSemanticCache
+      ? await getEmbedding(query, DEFAULT_EMBED_MODEL, true, options.session)
+      : null);
   if (queryEmbedding) {
     const semanticHit = lookupSemanticCache(db, queryEmbedding, semanticThreshold);
     if (semanticHit) {

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -828,12 +828,20 @@ function initializeDatabase(db: Database): void {
     CREATE TABLE IF NOT EXISTS semantic_cache (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       query TEXT NOT NULL,
+      model TEXT NOT NULL DEFAULT '${DEFAULT_QUERY_MODEL}',
       response TEXT NOT NULL,
       created_at TEXT NOT NULL,
       hits INTEGER NOT NULL DEFAULT 0
     )
   `);
+  const semanticCacheInfo = db.prepare(`PRAGMA table_info(semantic_cache)`).all() as { name: string }[];
+  const hasSemanticModelColumn = semanticCacheInfo.some(col => col.name === "model");
+  if (!hasSemanticModelColumn) {
+    db.exec(`ALTER TABLE semantic_cache ADD COLUMN model TEXT`);
+    db.prepare(`UPDATE semantic_cache SET model = ? WHERE model IS NULL OR model = ''`).run(DEFAULT_QUERY_MODEL);
+  }
   db.exec(`CREATE INDEX IF NOT EXISTS idx_semantic_cache_created_at ON semantic_cache(created_at)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_semantic_cache_model_created_at ON semantic_cache(model, created_at)`);
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS document_summaries (
@@ -1579,6 +1587,7 @@ type SemanticCacheHit = {
 
 function lookupSemanticCache(
   db: Database,
+  model: string,
   queryEmbedding: number[],
   threshold: number
 ): SemanticCacheHit | null {
@@ -1607,8 +1616,8 @@ function lookupSemanticCache(
   const rows = db.prepare(`
     SELECT id, response
     FROM semantic_cache
-    WHERE id IN (${placeholders}) AND created_at >= ?
-  `).all(...cacheIds, cutoff) as { id: number; response: string }[];
+    WHERE id IN (${placeholders}) AND model = ? AND created_at >= ?
+  `).all(...cacheIds, model, cutoff) as { id: number; response: string }[];
   if (rows.length === 0) return null;
 
   const rowById = new Map(rows.map(row => [row.id, row]));
@@ -1625,16 +1634,16 @@ function incrementSemanticCacheHit(db: Database, cacheId: number): void {
   db.prepare(`UPDATE semantic_cache SET hits = hits + 1 WHERE id = ?`).run(cacheId);
 }
 
-function insertSemanticCacheEntry(db: Database, query: string, response: string, queryEmbedding: number[]): void {
+function insertSemanticCacheEntry(db: Database, query: string, model: string, response: string, queryEmbedding: number[]): void {
   if (!semanticCacheTablesAvailable(db)) return;
   if (queryEmbedding.length !== SEMANTIC_CACHE_DIMENSIONS) return;
 
   const now = new Date().toISOString();
   runInTransaction(db, () => {
     const result = db.prepare(`
-      INSERT INTO semantic_cache (query, response, created_at, hits)
-      VALUES (?, ?, ?, 0)
-    `).run(query, response, now);
+      INSERT INTO semantic_cache (query, model, response, created_at, hits)
+      VALUES (?, ?, ?, ?, 0)
+    `).run(query, model, response, now);
     const cacheId = Number(result.lastInsertRowid);
     const cacheKey = String(cacheId);
     db.prepare(`
@@ -3023,12 +3032,11 @@ export async function expandQuery(
       ? await getEmbedding(query, DEFAULT_EMBED_MODEL, true, options.session)
       : null);
   if (queryEmbedding) {
-    const semanticHit = lookupSemanticCache(db, queryEmbedding, semanticThreshold);
+    const semanticHit = lookupSemanticCache(db, model, queryEmbedding, semanticThreshold);
     if (semanticHit) {
       const parsed = parseExpandedQueryArray(semanticHit.response);
       if (parsed) {
         incrementSemanticCacheHit(db, semanticHit.id);
-        setCachedResult(db, cacheKey, semanticHit.response);
         return parsed;
       }
     }
@@ -3048,7 +3056,7 @@ export async function expandQuery(
     const serialized = JSON.stringify(expanded);
     setCachedResult(db, cacheKey, serialized);
     if (queryEmbedding) {
-      insertSemanticCacheEntry(db, query, serialized, queryEmbedding);
+      insertSemanticCacheEntry(db, query, model, serialized, queryEmbedding);
     }
   }
 
@@ -3924,7 +3932,7 @@ export async function hybridQuery(
         process.stderr.write(
           `KINDX Warning: embedBatch failed during hybridQuery, falling back to FTS-only results. ${err}\n`
         );
-        fallbackOriginalEmbedding = null;
+        fallbackOriginalEmbedding = originalQueryEmbedding ?? null;
         expansionEmbeddings = textsToEmbed.map(() => null);
       }
       hooks?.onEmbedDone?.(Date.now() - embedStart);

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -50,6 +50,9 @@ export const DEFAULT_RERANK_MODEL = "ExpedientFalcon/qwen3-reranker:0.6b-Q8_0";
 export const DEFAULT_QUERY_MODEL = "Qwen/Qwen3-1.7B";
 export const DEFAULT_GLOB = "**/*.md";
 export const DEFAULT_MULTI_GET_MAX_BYTES = 10 * 1024; // 10KB
+export const SEMANTIC_CACHE_DIMENSIONS = 768;
+export const DEFAULT_SEMANTIC_CACHE_THRESHOLD = 0.92;
+export const DEFAULT_CACHE_TTL_HOURS = 168;
 
 // Chunking: 900 tokens per chunk with 15% overlap
 // Increased from 800 to accommodate smart chunking finding natural break points
@@ -253,6 +256,12 @@ export const RERANK_CANDIDATE_LIMIT = 40;
 export type ExpandedQuery = {
   type: 'lex' | 'vec' | 'hyde';
   text: string;
+};
+
+export type ExpandQueryOptions = {
+  queryEmbedding?: number[];
+  session?: ILLMSession;
+  semanticThreshold?: number;
 };
 
 // =============================================================================
@@ -816,6 +825,17 @@ function initializeDatabase(db: Database): void {
   `);
 
   db.exec(`
+    CREATE TABLE IF NOT EXISTS semantic_cache (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      query TEXT NOT NULL,
+      response TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      hits INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_semantic_cache_created_at ON semantic_cache(created_at)`);
+
+  db.exec(`
     CREATE TABLE IF NOT EXISTS document_summaries (
       doc_hash TEXT PRIMARY KEY,
       summary TEXT NOT NULL,
@@ -846,6 +866,25 @@ function initializeDatabase(db: Database): void {
   `);
   if (cvInfo.length > 0 && hasSeqColumn && !hasChunkHashColumn) {
     db.exec(`ALTER TABLE content_vectors ADD COLUMN chunk_hash TEXT`);
+  }
+
+  if (_sqliteVecAvailable) {
+    const semanticVecInfo = db.prepare(`
+      SELECT sql FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+    `).get() as { sql: string } | null;
+    if (semanticVecInfo) {
+      const match = semanticVecInfo.sql.match(/float\[(\d+)\]/);
+      const hasCacheKey = semanticVecInfo.sql.includes("cache_key");
+      const hasCosine = semanticVecInfo.sql.includes("distance_metric=cosine");
+      const existingDims = match?.[1] ? parseInt(match[1], 10) : null;
+      if (existingDims !== SEMANTIC_CACHE_DIMENSIONS || !hasCacheKey || !hasCosine) {
+        db.exec(`DROP TABLE IF EXISTS semantic_cache_vec`);
+      }
+    }
+    db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS semantic_cache_vec
+      USING vec0(cache_key TEXT PRIMARY KEY, embedding float[${SEMANTIC_CACHE_DIMENSIONS}] distance_metric=cosine)
+    `);
   }
 
   db.exec(`
@@ -1012,6 +1051,7 @@ export type Store = {
 
   // Cleanup and maintenance
   deleteLLMCache: () => number;
+  deleteSemanticCache: () => number;
   deleteInactiveDocuments: () => number;
   cleanupOrphanedContent: () => number;
   cleanupOrphanedVectors: () => number;
@@ -1036,7 +1076,7 @@ export type Store = {
   searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
-  expandQuery: (query: string, model?: string) => Promise<ExpandedQuery[]>;
+  expandQuery: (query: string, model?: string, options?: ExpandQueryOptions) => Promise<ExpandedQuery[]>;
   rerank: (query: string, documents: { file: string; text: string }[], model?: string) => Promise<{ file: string; score: number }[]>;
 
   // Document retrieval
@@ -1107,6 +1147,7 @@ export function createStore(dbPath?: string): Store {
 
     // Cleanup and maintenance
     deleteLLMCache: () => deleteLLMCache(db),
+    deleteSemanticCache: () => deleteSemanticCache(db),
     deleteInactiveDocuments: () => deleteInactiveDocuments(db),
     cleanupOrphanedContent: () => cleanupOrphanedContent(db),
     cleanupOrphanedVectors: () => cleanupOrphanedVectors(db),
@@ -1131,7 +1172,7 @@ export function createStore(dbPath?: string): Store {
     searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
 
     // Query expansion & reranking
-    expandQuery: (query: string, model?: string) => expandQuery(query, model, db),
+    expandQuery: (query: string, model?: string, options?: ExpandQueryOptions) => expandQuery(query, model, db, options),
     rerank: (query: string, documents: { file: string; text: string }[], model?: string) => rerank(query, documents, model, db),
 
     // Watcher integrations
@@ -1442,6 +1483,140 @@ export function clearCache(db: Database): void {
   db.exec(`DELETE FROM llm_cache`);
 }
 
+function getSemanticCacheThresholdValue(override?: number): number {
+  if (typeof override === "number" && Number.isFinite(override)) {
+    return Math.min(1, Math.max(0, override));
+  }
+  const raw = process.env.KINDX_SEMANTIC_CACHE_THRESHOLD;
+  if (!raw) return DEFAULT_SEMANTIC_CACHE_THRESHOLD;
+  const parsed = parseFloat(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_SEMANTIC_CACHE_THRESHOLD;
+  return Math.min(1, Math.max(0, parsed));
+}
+
+function getCacheTtlHoursValue(): number {
+  const raw = process.env.KINDX_CACHE_TTL_HOURS;
+  if (!raw) return DEFAULT_CACHE_TTL_HOURS;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CACHE_TTL_HOURS;
+  return parsed;
+}
+
+function semanticCacheTablesAvailable(db: Database): boolean {
+  if (!_sqliteVecAvailable) return false;
+  const cacheTable = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache'
+  `).get();
+  const vecTable = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+  `).get();
+  return !!cacheTable && !!vecTable;
+}
+
+function parseExpandedQueryArray(raw: string): ExpandedQuery[] | null {
+  try {
+    const parsed = JSON.parse(raw) as ExpandedQuery[];
+    if (!Array.isArray(parsed)) return null;
+    if (!parsed.every(item =>
+      item
+      && (item.type === "lex" || item.type === "vec" || item.type === "hyde")
+      && typeof item.text === "string"
+    )) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function pruneSemanticCacheByTtl(db: Database): number {
+  if (!semanticCacheTablesAvailable(db)) return 0;
+  const ttlMs = getCacheTtlHoursValue() * 60 * 60 * 1000;
+  const cutoff = new Date(Date.now() - ttlMs).toISOString();
+  const staleRows = db.prepare(`
+    SELECT id FROM semantic_cache WHERE created_at < ?
+  `).all(cutoff) as { id: number }[];
+  if (staleRows.length === 0) return 0;
+
+  const ids = staleRows.map(row => row.id);
+  const cacheKeys = ids.map(id => String(id));
+  const placeholders = ids.map(() => "?").join(",");
+  db.prepare(`DELETE FROM semantic_cache_vec WHERE cache_key IN (${placeholders})`).run(...cacheKeys);
+  db.prepare(`DELETE FROM semantic_cache WHERE id IN (${placeholders})`).run(...ids);
+  return ids.length;
+}
+
+type SemanticCacheHit = {
+  id: number;
+  response: string;
+  similarity: number;
+};
+
+function lookupSemanticCache(
+  db: Database,
+  queryEmbedding: number[],
+  threshold: number
+): SemanticCacheHit | null {
+  if (!semanticCacheTablesAvailable(db)) return null;
+  if (queryEmbedding.length !== SEMANTIC_CACHE_DIMENSIONS) return null;
+
+  pruneSemanticCacheByTtl(db);
+
+  const vecRows = db.prepare(`
+    SELECT cache_key, distance
+    FROM semantic_cache_vec
+    WHERE embedding MATCH ? AND k = 5
+  `).all(new Float32Array(queryEmbedding)) as { cache_key: string; distance: number }[];
+  if (vecRows.length === 0) return null;
+
+  const candidateRows = vecRows
+    .map(row => ({ cacheId: parseInt(row.cache_key, 10), similarity: 1 - row.distance }))
+    .filter(row => Number.isInteger(row.cacheId))
+    .filter(row => row.similarity >= threshold)
+    .sort((a, b) => b.similarity - a.similarity);
+  if (candidateRows.length === 0) return null;
+
+  const cacheIds = candidateRows.map(row => row.cacheId);
+  const placeholders = cacheIds.map(() => "?").join(",");
+  const rows = db.prepare(`
+    SELECT id, response
+    FROM semantic_cache
+    WHERE id IN (${placeholders})
+  `).all(...cacheIds) as { id: number; response: string }[];
+  if (rows.length === 0) return null;
+
+  const rowById = new Map(rows.map(row => [row.id, row]));
+  for (const candidate of candidateRows) {
+    const hit = rowById.get(candidate.cacheId);
+    if (hit) {
+      return { id: hit.id, response: hit.response, similarity: candidate.similarity };
+    }
+  }
+  return null;
+}
+
+function incrementSemanticCacheHit(db: Database, cacheId: number): void {
+  db.prepare(`UPDATE semantic_cache SET hits = hits + 1 WHERE id = ?`).run(cacheId);
+}
+
+function insertSemanticCacheEntry(db: Database, query: string, response: string, queryEmbedding: number[]): void {
+  if (!semanticCacheTablesAvailable(db)) return;
+  if (queryEmbedding.length !== SEMANTIC_CACHE_DIMENSIONS) return;
+
+  const now = new Date().toISOString();
+  const result = db.prepare(`
+    INSERT INTO semantic_cache (query, response, created_at, hits)
+    VALUES (?, ?, ?, 0)
+  `).run(query, response, now);
+  const cacheId = Number(result.lastInsertRowid);
+  const cacheKey = String(cacheId);
+  db.prepare(`
+    INSERT OR REPLACE INTO semantic_cache_vec (cache_key, embedding)
+    VALUES (?, ?)
+  `).run(cacheKey, new Float32Array(queryEmbedding));
+}
+
 // =============================================================================
 // Cleanup and maintenance operations
 // =============================================================================
@@ -1453,6 +1628,34 @@ export function clearCache(db: Database): void {
 export function deleteLLMCache(db: Database): number {
   const result = db.prepare(`DELETE FROM llm_cache`).run();
   return result.changes;
+}
+
+/**
+ * Delete semantic query-expansion cache entries (table + vector table rows).
+ */
+export function deleteSemanticCache(db: Database): number {
+  const tableExists = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache'
+  `).get();
+  if (!tableExists) return 0;
+
+  const countRow = db.prepare(`SELECT COUNT(*) as count FROM semantic_cache`).get() as { count: number };
+  if (countRow.count === 0) return 0;
+
+  db.exec(`DELETE FROM semantic_cache`);
+  const semanticVecExists = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+  `).get();
+  if (semanticVecExists) {
+    db.exec(`DELETE FROM semantic_cache_vec`);
+  }
+  return countRow.count;
+}
+
+export function shouldInvalidateSemanticCache(changedCount: number, activeDocsBefore: number): boolean {
+  if (changedCount <= 0) return false;
+  if (activeDocsBefore <= 0) return true;
+  return (changedCount / activeDocsBefore) > 0.10;
 }
 
 /**
@@ -2760,19 +2963,38 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database): Promise<ExpandedQuery[]> {
+export async function expandQuery(
+  query: string,
+  model: string = DEFAULT_QUERY_MODEL,
+  db: Database,
+  options: ExpandQueryOptions = {}
+): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model });
   const cached = getCachedResult(db, cacheKey);
   if (cached) {
-    try {
-      return JSON.parse(cached) as ExpandedQuery[];
-    } catch {
-      // Old cache format (pre-typed, newline-separated text) — re-expand
+    const parsed = parseExpandedQueryArray(cached);
+    if (parsed) {
+      return parsed;
     }
   }
 
-  const llm = getDefaultLLM();
+  const semanticThreshold = getSemanticCacheThresholdValue(options.semanticThreshold);
+  const queryEmbedding = options.queryEmbedding
+    ?? await getEmbedding(query, DEFAULT_EMBED_MODEL, true, options.session);
+  if (queryEmbedding) {
+    const semanticHit = lookupSemanticCache(db, queryEmbedding, semanticThreshold);
+    if (semanticHit) {
+      const parsed = parseExpandedQueryArray(semanticHit.response);
+      if (parsed) {
+        incrementSemanticCacheHit(db, semanticHit.id);
+        setCachedResult(db, cacheKey, semanticHit.response);
+        return parsed;
+      }
+    }
+  }
+
+  const llm = options.session ?? getDefaultLLM();
   // Note: LLM usages rely on configuration logic internally
   const results = await llm.expandQuery(query);
 
@@ -2783,7 +3005,11 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
     .map(r => ({ type: r.type, text: r.text }));
 
   if (expanded.length > 0) {
-    setCachedResult(db, cacheKey, JSON.stringify(expanded));
+    const serialized = JSON.stringify(expanded);
+    setCachedResult(db, cacheKey, serialized);
+    if (queryEmbedding) {
+      insertSemanticCacheEntry(db, query, serialized, queryEmbedding);
+    }
   }
 
   return expanded;
@@ -3573,6 +3799,9 @@ export async function hybridQuery(
   const hasVectors = !!store.db.prepare(
     `SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`
   ).get();
+  const originalQueryEmbedding = hasVectors
+    ? await getEmbedding(query, DEFAULT_EMBED_MODEL, true)
+    : null;
 
   // Step 1: BM25 probe — strong signal skips expensive LLM expansion
   // Pass collection directly into FTS query (filter at SQL level, not post-hoc)
@@ -3590,7 +3819,9 @@ export async function hybridQuery(
   const expandStart = Date.now();
   const expanded = hasStrongSignal
     ? []
-    : await store.expandQuery(query);
+    : await store.expandQuery(query, DEFAULT_QUERY_MODEL, {
+      queryEmbedding: originalQueryEmbedding ?? undefined,
+    });
 
   hooks?.onExpand?.(query, expanded, Date.now() - expandStart);
 
@@ -3625,40 +3856,60 @@ export async function hybridQuery(
     }
   }
 
-  // 3b: Collect all texts that need vector search (original query + vec/hyde expansions)
+  // 3b: Run vector searches for original query + vec/hyde expansions.
+  // Reuse the original query embedding to avoid duplicate embedding work.
   if (hasVectors) {
-    const vecQueries: { text: string; queryType: "original" | "vec" | "hyde" }[] = [
-      { text: query, queryType: "original" },
-    ];
-    for (const q of expanded) {
-      if (q.type === 'vec' || q.type === 'hyde') {
-        vecQueries.push({ text: q.text, queryType: q.type });
+    const llm = getDefaultLLM();
+    const expansionVecQueries = expanded.filter(
+      (q): q is ExpandedQuery & { type: "vec" | "hyde" } => q.type === "vec" || q.type === "hyde"
+    );
+    const textsToEmbed = expansionVecQueries.map(q => formatQueryForEmbedding(q.text));
+    const embedTargets = textsToEmbed.length + (originalQueryEmbedding ? 0 : 1);
+
+    let fallbackOriginalEmbedding: number[] | null = originalQueryEmbedding;
+    let expansionEmbeddings: Awaited<ReturnType<typeof llm.embedBatch>> = [];
+    if (embedTargets > 0) {
+      hooks?.onEmbedStart?.(embedTargets);
+      const embedStart = Date.now();
+      try {
+        if (originalQueryEmbedding) {
+          expansionEmbeddings = textsToEmbed.length > 0 ? await llm.embedBatch(textsToEmbed) : [];
+        } else {
+          const batchInput = [formatQueryForEmbedding(query), ...textsToEmbed];
+          const embedded = await llm.embedBatch(batchInput);
+          fallbackOriginalEmbedding = embedded[0]?.embedding ?? null;
+          expansionEmbeddings = embedded.slice(1);
+        }
+      } catch (err) {
+        process.stderr.write(
+          `KINDX Warning: embedBatch failed during hybridQuery, falling back to FTS-only results. ${err}\n`
+        );
+        fallbackOriginalEmbedding = null;
+        expansionEmbeddings = textsToEmbed.map(() => null);
+      }
+      hooks?.onEmbedDone?.(Date.now() - embedStart);
+    }
+
+    if (fallbackOriginalEmbedding) {
+      const originalVecResults = await store.searchVec(
+        query, DEFAULT_EMBED_MODEL, 20, collection, undefined, fallbackOriginalEmbedding
+      );
+      if (originalVecResults.length > 0) {
+        for (const r of originalVecResults) docidMap.set(r.filepath, r.docid);
+        rankedLists.push(originalVecResults.map(r => ({
+          file: r.filepath, displayPath: r.displayPath,
+          title: r.title, body: r.body || "", score: r.score, hash: r.hash,
+        })));
+        rankedListMeta.push({ source: "vec", queryType: "original", query });
       }
     }
 
-    // Batch embed all vector queries in a single call
-    const llm = getDefaultLLM();
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text));
-    hooks?.onEmbedStart?.(textsToEmbed.length);
-    const embedStart = Date.now();
-    let embeddings: Awaited<ReturnType<typeof llm.embedBatch>>;
-    try {
-      embeddings = await llm.embedBatch(textsToEmbed);
-    } catch (err) {
-      process.stderr.write(
-        `KINDX Warning: embedBatch failed during hybridQuery, falling back to FTS-only results. ${err}\n`
-      );
-      embeddings = textsToEmbed.map(() => null);
-    }
-    hooks?.onEmbedDone?.(Date.now() - embedStart);
-
-    // Run sqlite-vec lookups with pre-computed embeddings
-    for (let i = 0; i < vecQueries.length; i++) {
-      const embedding = embeddings[i]?.embedding;
+    for (let i = 0; i < expansionVecQueries.length; i++) {
+      const embedding = expansionEmbeddings[i]?.embedding;
       if (!embedding) continue;
 
       const vecResults = await store.searchVec(
-        vecQueries[i]!.text, DEFAULT_EMBED_MODEL, 20, collection,
+        expansionVecQueries[i]!.text, DEFAULT_EMBED_MODEL, 20, collection,
         undefined, embedding
       );
       if (vecResults.length > 0) {
@@ -3669,8 +3920,8 @@ export async function hybridQuery(
         })));
         rankedListMeta.push({
           source: "vec",
-          queryType: vecQueries[i]!.queryType,
-          query: vecQueries[i]!.text,
+          queryType: expansionVecQueries[i]!.type,
+          query: expansionVecQueries[i]!.text,
         });
       }
     }

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -3847,9 +3847,17 @@ export async function hybridQuery(
   const hasVectors = !!store.db.prepare(
     `SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`
   ).get();
-  const originalQueryEmbedding = hasVectors
-    ? await getEmbedding(query, DEFAULT_EMBED_MODEL, true)
-    : null;
+  let originalQueryEmbedding: number[] | null = null;
+  if (hasVectors) {
+    try {
+      originalQueryEmbedding = await getEmbedding(query, DEFAULT_EMBED_MODEL, true);
+    } catch (err) {
+      process.stderr.write(
+        `KINDX Warning: failed to precompute original query embedding, falling back to FTS-only until embedding recovery. ${err}\n`
+      );
+      originalQueryEmbedding = null;
+    }
+  }
 
   // Step 1: BM25 probe — strong signal skips expensive LLM expansion
   // Pass collection directly into FTS query (filter at SQL level, not post-hoc)

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -879,6 +879,7 @@ function initializeDatabase(db: Database): void {
       const existingDims = match?.[1] ? parseInt(match[1], 10) : null;
       if (existingDims !== SEMANTIC_CACHE_DIMENSIONS || !hasCacheKey || !hasCosine) {
         db.exec(`DROP TABLE IF EXISTS semantic_cache_vec`);
+        db.exec(`DELETE FROM semantic_cache`);
       }
     }
     db.exec(`
@@ -1502,6 +1503,11 @@ function getCacheTtlHoursValue(): number {
   return parsed;
 }
 
+function getSemanticCacheTtlCutoff(): string {
+  const ttlMs = getCacheTtlHoursValue() * 60 * 60 * 1000;
+  return new Date(Date.now() - ttlMs).toISOString();
+}
+
 function semanticCacheTablesAvailable(db: Database): boolean {
   if (!_sqliteVecAvailable) return false;
   const cacheTable = db.prepare(`
@@ -1530,21 +1536,39 @@ function parseExpandedQueryArray(raw: string): ExpandedQuery[] | null {
   }
 }
 
+function runInTransaction(db: Database, action: () => void): void {
+  db.exec(`BEGIN`);
+  try {
+    action();
+    db.exec(`COMMIT`);
+  } catch (error) {
+    db.exec(`ROLLBACK`);
+    throw error;
+  }
+}
+
 function pruneSemanticCacheByTtl(db: Database): number {
   if (!semanticCacheTablesAvailable(db)) return 0;
-  const ttlMs = getCacheTtlHoursValue() * 60 * 60 * 1000;
-  const cutoff = new Date(Date.now() - ttlMs).toISOString();
-  const staleRows = db.prepare(`
-    SELECT id FROM semantic_cache WHERE created_at < ?
-  `).all(cutoff) as { id: number }[];
-  if (staleRows.length === 0) return 0;
+  const cutoff = getSemanticCacheTtlCutoff();
+  const staleCount = (db.prepare(`
+    SELECT COUNT(*) as count FROM semantic_cache WHERE created_at < ?
+  `).get(cutoff) as { count: number }).count;
+  if (staleCount === 0) return 0;
+  runInTransaction(db, () => {
+    db.prepare(`
+      DELETE FROM semantic_cache_vec
+      WHERE cache_key IN (SELECT CAST(id AS TEXT) FROM semantic_cache WHERE created_at < ?)
+    `).run(cutoff);
+    db.prepare(`DELETE FROM semantic_cache WHERE created_at < ?`).run(cutoff);
+  });
+  return staleCount;
+}
 
-  const ids = staleRows.map(row => row.id);
-  const cacheKeys = ids.map(id => String(id));
-  const placeholders = ids.map(() => "?").join(",");
-  db.prepare(`DELETE FROM semantic_cache_vec WHERE cache_key IN (${placeholders})`).run(...cacheKeys);
-  db.prepare(`DELETE FROM semantic_cache WHERE id IN (${placeholders})`).run(...ids);
-  return ids.length;
+function maybePruneSemanticCacheByTtl(db: Database): void {
+  // Keep lookup hot path fast while still eventually reclaiming stale entries.
+  if (Math.random() < 0.01) {
+    pruneSemanticCacheByTtl(db);
+  }
 }
 
 type SemanticCacheHit = {
@@ -1561,7 +1585,7 @@ function lookupSemanticCache(
   if (!semanticCacheTablesAvailable(db)) return null;
   if (queryEmbedding.length !== SEMANTIC_CACHE_DIMENSIONS) return null;
 
-  pruneSemanticCacheByTtl(db);
+  maybePruneSemanticCacheByTtl(db);
 
   const vecRows = db.prepare(`
     SELECT cache_key, distance
@@ -1579,11 +1603,12 @@ function lookupSemanticCache(
 
   const cacheIds = candidateRows.map(row => row.cacheId);
   const placeholders = cacheIds.map(() => "?").join(",");
+  const cutoff = getSemanticCacheTtlCutoff();
   const rows = db.prepare(`
     SELECT id, response
     FROM semantic_cache
-    WHERE id IN (${placeholders})
-  `).all(...cacheIds) as { id: number; response: string }[];
+    WHERE id IN (${placeholders}) AND created_at >= ?
+  `).all(...cacheIds, cutoff) as { id: number; response: string }[];
   if (rows.length === 0) return null;
 
   const rowById = new Map(rows.map(row => [row.id, row]));
@@ -1605,16 +1630,19 @@ function insertSemanticCacheEntry(db: Database, query: string, response: string,
   if (queryEmbedding.length !== SEMANTIC_CACHE_DIMENSIONS) return;
 
   const now = new Date().toISOString();
-  const result = db.prepare(`
-    INSERT INTO semantic_cache (query, response, created_at, hits)
-    VALUES (?, ?, ?, 0)
-  `).run(query, response, now);
-  const cacheId = Number(result.lastInsertRowid);
-  const cacheKey = String(cacheId);
-  db.prepare(`
-    INSERT OR REPLACE INTO semantic_cache_vec (cache_key, embedding)
-    VALUES (?, ?)
-  `).run(cacheKey, new Float32Array(queryEmbedding));
+  runInTransaction(db, () => {
+    const result = db.prepare(`
+      INSERT INTO semantic_cache (query, response, created_at, hits)
+      VALUES (?, ?, ?, 0)
+    `).run(query, response, now);
+    const cacheId = Number(result.lastInsertRowid);
+    const cacheKey = String(cacheId);
+    db.prepare(`
+      INSERT OR REPLACE INTO semantic_cache_vec (cache_key, embedding)
+      VALUES (?, ?)
+    `).run(cacheKey, new Float32Array(queryEmbedding));
+  });
+  pruneSemanticCacheByTtl(db);
 }
 
 // =============================================================================
@@ -1642,13 +1670,15 @@ export function deleteSemanticCache(db: Database): number {
   const countRow = db.prepare(`SELECT COUNT(*) as count FROM semantic_cache`).get() as { count: number };
   if (countRow.count === 0) return 0;
 
-  db.exec(`DELETE FROM semantic_cache`);
-  const semanticVecExists = db.prepare(`
-    SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
-  `).get();
-  if (semanticVecExists) {
-    db.exec(`DELETE FROM semantic_cache_vec`);
-  }
+  runInTransaction(db, () => {
+    db.exec(`DELETE FROM semantic_cache`);
+    const semanticVecExists = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+    `).get();
+    if (semanticVecExists) {
+      db.exec(`DELETE FROM semantic_cache_vec`);
+    }
+  });
   return countRow.count;
 }
 

--- a/specs/command-line.test.ts
+++ b/specs/command-line.test.ts
@@ -561,9 +561,9 @@ describe("CLI Cleanup Command", () => {
     `).get();
     if (semanticExists) {
       db.prepare(`
-        INSERT INTO semantic_cache (query, response, created_at, hits)
-        VALUES (?, ?, ?, 0)
-      `).run("deploy steps", '[{"type":"vec","text":"deployment guide"}]', new Date().toISOString());
+        INSERT INTO semantic_cache (query, model, response, created_at, hits)
+        VALUES (?, ?, ?, ?, 0)
+      `).run("deploy steps", "qwen2.5-coder:1.5b", '[{"type":"vec","text":"deployment guide"}]', new Date().toISOString());
     }
     db.close();
 

--- a/specs/command-line.test.ts
+++ b/specs/command-line.test.ts
@@ -548,6 +548,38 @@ describe("CLI Cleanup Command", () => {
     const { stdout, exitCode } = await runQmd(["cleanup"]);
     expect(exitCode).toBe(0);
   });
+
+  test("cleanup --cache purges llm and semantic caches", async () => {
+    const db = new Database(testDbPath);
+    db.prepare(`
+      INSERT OR REPLACE INTO llm_cache (hash, result, created_at)
+      VALUES (?, ?, ?)
+    `).run("cache-key", "cached-result", new Date().toISOString());
+
+    const semanticExists = !!db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache'
+    `).get();
+    if (semanticExists) {
+      db.prepare(`
+        INSERT INTO semantic_cache (query, response, created_at, hits)
+        VALUES (?, ?, ?, 0)
+      `).run("deploy steps", '[{"type":"vec","text":"deployment guide"}]', new Date().toISOString());
+    }
+    db.close();
+
+    const { exitCode } = await runQmd(["cleanup", "--cache"]);
+    expect(exitCode).toBe(0);
+
+    const verifyDb = new Database(testDbPath, { readonly: true });
+    const llmCount = (verifyDb.prepare(`SELECT COUNT(*) as count FROM llm_cache`).get() as { count: number }).count;
+    expect(llmCount).toBe(0);
+
+    if (semanticExists) {
+      const semanticCount = (verifyDb.prepare(`SELECT COUNT(*) as count FROM semantic_cache`).get() as { count: number }).count;
+      expect(semanticCount).toBe(0);
+    }
+    verifyDb.close();
+  });
 });
 
 describe("CLI Error Handling", () => {

--- a/specs/store.test.ts
+++ b/specs/store.test.ts
@@ -2618,6 +2618,73 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
     await cleanupTestDb(store);
   }, 30000);
 
+  test("rerank scores documents", async () => {
+    const store = await createTestStore();
+
+    const docs = [
+      { file: "doc1.md", text: "Relevant content about the topic" },
+      { file: "doc2.md", text: "Other content" },
+    ];
+
+    const results = await store.rerank("topic", docs);
+    expect(results).toHaveLength(2);
+    // LlamaCpp reranker returns relevance scores
+    expect(results[0]!.score).toBeGreaterThan(0);
+
+    await cleanupTestDb(store);
+  });
+
+  test("rerank caches results", async () => {
+    const store = await createTestStore();
+
+    const docs = [{ file: "doc1.md", text: "Content for caching test" }];
+
+    // First call
+    await store.rerank("cache test query", docs);
+    // Second call - should hit cache
+    const results = await store.rerank("cache test query", docs);
+
+    expect(results).toHaveLength(1);
+
+    await cleanupTestDb(store);
+  });
+
+  test("rerank deduplicates identical chunks across files", async () => {
+    const store = await createTestStore();
+    const rerankSpy = vi.fn(async (_query: string, docs: { file: string; text: string }[]) => ({
+      results: docs.map((doc, index) => ({
+        file: doc.file,
+        score: 1 - index * 0.1,
+        index,
+      })),
+      model: "mock-reranker",
+    }));
+
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue({
+      rerank: rerankSpy,
+    } as any);
+
+    try {
+      const docs = [
+        { file: "doc1.md", text: "Shared chunk text" },
+        { file: "doc2.md", text: "Shared chunk text" },
+      ];
+
+      const first = await store.rerank("shared", docs);
+      const second = await store.rerank("shared", docs);
+
+      expect(first).toHaveLength(2);
+      expect(second).toHaveLength(2);
+      expect(rerankSpy).toHaveBeenCalledTimes(1);
+      expect(rerankSpy.mock.calls[0]?.[1]).toEqual([{ file: "doc2.md", text: "Shared chunk text" }]);
+    } finally {
+      llmSpy.mockRestore();
+      await cleanupTestDb(store);
+    }
+  });
+});
+
+describe("Semantic Expansion Cache", () => {
   test("expandQuery reuses semantic cache for paraphrased query", async () => {
     const store = await createTestStore();
     const hasSemanticVec = !!store.db.prepare(`
@@ -2728,76 +2795,11 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
     }
   });
 
-  test("rerank scores documents", async () => {
-    const store = await createTestStore();
-
-    const docs = [
-      { file: "doc1.md", text: "Relevant content about the topic" },
-      { file: "doc2.md", text: "Other content" },
-    ];
-
-    const results = await store.rerank("topic", docs);
-    expect(results).toHaveLength(2);
-    // LlamaCpp reranker returns relevance scores
-    expect(results[0]!.score).toBeGreaterThan(0);
-
-    await cleanupTestDb(store);
-  });
-
   test("shouldInvalidateSemanticCache triggers only when change ratio is above 10%", () => {
     expect(shouldInvalidateSemanticCache(11, 100)).toBe(true);
     expect(shouldInvalidateSemanticCache(10, 100)).toBe(false);
     expect(shouldInvalidateSemanticCache(0, 100)).toBe(false);
     expect(shouldInvalidateSemanticCache(1, 0)).toBe(true);
-  });
-
-  test("rerank caches results", async () => {
-    const store = await createTestStore();
-
-    const docs = [{ file: "doc1.md", text: "Content for caching test" }];
-
-    // First call
-    await store.rerank("cache test query", docs);
-    // Second call - should hit cache
-    const results = await store.rerank("cache test query", docs);
-
-    expect(results).toHaveLength(1);
-
-    await cleanupTestDb(store);
-  });
-
-  test("rerank deduplicates identical chunks across files", async () => {
-    const store = await createTestStore();
-    const rerankSpy = vi.fn(async (_query: string, docs: { file: string; text: string }[]) => ({
-      results: docs.map((doc, index) => ({
-        file: doc.file,
-        score: 1 - index * 0.1,
-        index,
-      })),
-      model: "mock-reranker",
-    }));
-
-    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue({
-      rerank: rerankSpy,
-    } as any);
-
-    try {
-      const docs = [
-        { file: "doc1.md", text: "Shared chunk text" },
-        { file: "doc2.md", text: "Shared chunk text" },
-      ];
-
-      const first = await store.rerank("shared", docs);
-      const second = await store.rerank("shared", docs);
-
-      expect(first).toHaveLength(2);
-      expect(second).toHaveLength(2);
-      expect(rerankSpy).toHaveBeenCalledTimes(1);
-      expect(rerankSpy.mock.calls[0]?.[1]).toEqual([{ file: "doc2.md", text: "Shared chunk text" }]);
-    } finally {
-      llmSpy.mockRestore();
-      await cleanupTestDb(store);
-    }
   });
 });
 

--- a/specs/store.test.ts
+++ b/specs/store.test.ts
@@ -56,6 +56,7 @@ import {
   isDocid,
   STRONG_SIGNAL_MIN_SCORE,
   STRONG_SIGNAL_MIN_GAP,
+  shouldInvalidateSemanticCache,
   type Store,
   type DocumentResult,
   type SearchResult,
@@ -2617,6 +2618,116 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
     await cleanupTestDb(store);
   }, 30000);
 
+  test("expandQuery reuses semantic cache for paraphrased query", async () => {
+    const store = await createTestStore();
+    const hasSemanticVec = !!store.db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+    `).get();
+    if (!hasSemanticVec) {
+      await cleanupTestDb(store);
+      return;
+    }
+
+    const sharedEmbedding = new Array(768).fill(0);
+    sharedEmbedding[0] = 1;
+    const expandResult = [
+      { type: "vec", text: "deployment instructions" },
+      { type: "hyde", text: "Deployment checklist for production rollout." },
+    ];
+
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue({
+      embed: vi.fn(async () => ({ embedding: sharedEmbedding })),
+      expandQuery: vi.fn(async () => expandResult),
+    } as any);
+
+    try {
+      const first = await store.expandQuery("deploy steps");
+      const second = await store.expandQuery("how to deploy");
+
+      expect(first).toEqual(expandResult);
+      expect(second).toEqual(expandResult);
+      const llm = llmSpy.mock.results[0]?.value as any;
+      expect(llm.expandQuery).toHaveBeenCalledTimes(1);
+
+      const hitRow = store.db.prepare(`
+        SELECT hits FROM semantic_cache ORDER BY id ASC LIMIT 1
+      `).get() as { hits: number } | undefined;
+      expect((hitRow?.hits ?? 0)).toBeGreaterThan(0);
+    } finally {
+      llmSpy.mockRestore();
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("expandQuery semantic cache respects threshold boundary", async () => {
+    const store = await createTestStore();
+    const hasSemanticVec = !!store.db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+    `).get();
+    if (!hasSemanticVec) {
+      await cleanupTestDb(store);
+      return;
+    }
+
+    process.env.KINDX_SEMANTIC_CACHE_THRESHOLD = "0.95";
+    const llm = {
+      embed: vi.fn(async (text: string) => {
+        const embedding = new Array(768).fill(0);
+        if (text.includes("deploy steps")) {
+          embedding[0] = 1;
+        } else {
+          embedding[0] = 0.9;
+          embedding[1] = Math.sqrt(1 - 0.9 * 0.9);
+        }
+        return { embedding };
+      }),
+      expandQuery: vi.fn(async () => [{ type: "vec", text: "deploy guide" }]),
+    };
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue(llm as any);
+
+    try {
+      await store.expandQuery("deploy steps");
+      await store.expandQuery("deployment instructions");
+      expect(llm.expandQuery).toHaveBeenCalledTimes(2);
+    } finally {
+      delete process.env.KINDX_SEMANTIC_CACHE_THRESHOLD;
+      llmSpy.mockRestore();
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("expandQuery semantic cache honors TTL", async () => {
+    const store = await createTestStore();
+    const hasSemanticVec = !!store.db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+    `).get();
+    if (!hasSemanticVec) {
+      await cleanupTestDb(store);
+      return;
+    }
+
+    process.env.KINDX_CACHE_TTL_HOURS = "1";
+    const embedding = new Array(768).fill(0);
+    embedding[0] = 1;
+    const llm = {
+      embed: vi.fn(async () => ({ embedding })),
+      expandQuery: vi.fn(async () => [{ type: "vec", text: "deploy guide" }]),
+    };
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue(llm as any);
+
+    try {
+      await store.expandQuery("deploy steps");
+      const oldTimestamp = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      store.db.prepare(`UPDATE semantic_cache SET created_at = ?`).run(oldTimestamp);
+      await store.expandQuery("deployment instructions");
+      expect(llm.expandQuery).toHaveBeenCalledTimes(2);
+    } finally {
+      delete process.env.KINDX_CACHE_TTL_HOURS;
+      llmSpy.mockRestore();
+      await cleanupTestDb(store);
+    }
+  });
+
   test("rerank scores documents", async () => {
     const store = await createTestStore();
 
@@ -2631,6 +2742,13 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
     expect(results[0]!.score).toBeGreaterThan(0);
 
     await cleanupTestDb(store);
+  });
+
+  test("shouldInvalidateSemanticCache triggers only when change ratio is above 10%", () => {
+    expect(shouldInvalidateSemanticCache(11, 100)).toBe(true);
+    expect(shouldInvalidateSemanticCache(10, 100)).toBe(false);
+    expect(shouldInvalidateSemanticCache(0, 100)).toBe(false);
+    expect(shouldInvalidateSemanticCache(1, 0)).toBe(true);
   });
 
   test("rerank caches results", async () => {

--- a/specs/store.test.ts
+++ b/specs/store.test.ts
@@ -2763,6 +2763,34 @@ describe("Semantic Expansion Cache", () => {
     }
   });
 
+  test("expandQuery semantic cache is scoped by expansion model", async () => {
+    const store = await createTestStore();
+    const hasSemanticVec = !!store.db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='semantic_cache_vec'
+    `).get();
+    if (!hasSemanticVec) {
+      await cleanupTestDb(store);
+      return;
+    }
+
+    const embedding = new Array(768).fill(0);
+    embedding[0] = 1;
+    const llm = {
+      embed: vi.fn(async () => ({ embedding })),
+      expandQuery: vi.fn(async () => [{ type: "vec", text: "deploy guide" }]),
+    };
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue(llm as any);
+
+    try {
+      await store.expandQuery("deploy steps", "model-a");
+      await store.expandQuery("deployment instructions", "model-b");
+      expect(llm.expandQuery).toHaveBeenCalledTimes(2);
+    } finally {
+      llmSpy.mockRestore();
+      await cleanupTestDb(store);
+    }
+  });
+
   test("expandQuery semantic cache honors TTL", async () => {
     const store = await createTestStore();
     const hasSemanticVec = !!store.db.prepare(`


### PR DESCRIPTION
## Linked Issue

Fixes #18

## Summary

This PR implements semantic query-expansion caching to avoid repeated LLM expansion calls for semantically equivalent queries.
It adds a new `semantic_cache` table plus `semantic_cache_vec` for cosine-similarity lookup, with default threshold `0.92` and TTL `168h` configurable via `KINDX_SEMANTIC_CACHE_THRESHOLD` and `KINDX_CACHE_TTL_HOURS`.
Hybrid query now reuses the original query embedding for semantic cache lookup and vector retrieval to avoid duplicate embedding work.
Cleanup flow now supports `kindx cleanup --cache` (cache-only purge), while `kindx cleanup` keeps full maintenance behavior.
Cache invalidation now flushes semantic cache when corpus delta is greater than 10% during indexing/embedding.

## Scope Boundaries

- This PR targets query-expansion caching only; rerank caching logic and non-expansion cache keys are unchanged.
- No MCP API shape changes are introduced.
- No release/publishing workflow changes are included.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [x] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD change

## Testing Evidence

- [x] `npm run build`
- [x] `npm test`
- [x] Focused test(s):
  - `npx vitest run specs/store.test.ts -t "semantic cache|shouldInvalidateSemanticCache|caches results as JSON" --reporter=verbose`
  - `npx vitest run specs/command-line.test.ts -t "cleanup --cache|CLI Cleanup Command" --reporter=verbose`
- [x] Manual verification:
  - Real local semantic-cache run (non-mocked expansion path) showed first query populating cache and paraphrases incrementing semantic `hits` while latency dropped from ~2095ms to ~10ms/~8ms.

## Risk / Rollback

Risk is low-to-moderate and scoped to query-expansion caching behavior. If any regression is found, rollback can be done by reverting this PR, or by temporarily disabling semantic reuse operationally via `KINDX_SEMANTIC_CACHE_THRESHOLD=1`.

## Docs Impact

README updated for:
- `kindx cleanup --cache`
- semantic cache schema entries
- `KINDX_SEMANTIC_CACHE_THRESHOLD` and `KINDX_CACHE_TTL_HOURS`

## Release Note Impact

Improves hybrid-query responsiveness by reusing expansion results across semantically similar queries; adds cache-only cleanup option.

## Reviewer Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have documented any non-obvious code paths or intentionally omitted them because the code is already clear
- [x] I updated the relevant docs, or documented why no docs change is required
- [x] I called out scope boundaries, risk, and rollout considerations above
- [x] I added or updated tests that prove the change works
- [x] New and existing tests pass locally, or I documented the known test limitation above
- [x] My commit messages follow the Conventional Commits format
- [x] This PR is linked to an issue (`Fixes #N`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `kindx cleanup --cache` to purge semantic and LLM caches only.
  * Persistent semantic query-expansion cache with stored embeddings.
  * Indexing/embedding now trigger semantic-cache invalidation when many documents change.

* **Documentation**
  * Updated CLI help, README cache guidance, schema docs, and environment variable docs.
  * New env vars: KINDX_SEMANTIC_CACHE_THRESHOLD, KINDX_CACHE_TTL_HOURS.

* **Tests**
  * Added integration/unit tests covering cache behavior, TTL, threshold, and invalidation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->