### PR TITLE
fix: resolve #54 — Beginner Issue: Support `~` expansion for YAML-defined collection paths and update `sample-catalog.yml`

### DIFF
--- a/sample-catalog.yml
+++ b/sample-catalog.yml
@@ -3,6 +3,8 @@
 #
 # This file defines all collections and their contexts.
 # You can manually edit this file - changes take effect immediately.
+#
+# Note: All paths must be absolute paths. Relative paths are not supported.
 
 # Global context applied to all collections
 # Use this for universal search instructions or patterns
@@ -12,14 +14,14 @@ global_context: "If you see a relevant [[WikiWord]], you can search for that Wik
 collections:
   # Meeting notes
   Meetings:
-    path: ~/Documents/Meetings
+    path: /absolute/path/to/meetings
     pattern: "**/*.md"
     context:
       "/": "Meeting notes and summaries"
 
   # Daily journal entries
   journals:
-    path: ~/Documents/Notes
+    path: /absolute/path/to/notes
     pattern: "**/*.md"
     context:
       "/journal/2024": "Daily notes from 2024"
@@ -27,7 +29,7 @@ collections:
       "/": "Notes vault"
 
   codex:
-    path: ~/Documents/Codex
+    path: /absolute/path/to/codex
     pattern: "**/*.md"
     context:
       "/": "Thematic collections of important concepts and discussions"


### PR DESCRIPTION
## Summary

fix: resolve #54 — Beginner Issue: Support `~` expansion for YAML-defined collection paths and update `sample-catalog.yml`

## Problem

**Severity**: `Low` | **File**: `sample-catalog.yml`

The sample catalog currently uses `~/Documents/Meetings` format which is misleading since tilde expansion isn't implemented. Update paths to be absolute paths or add documentation noting the tilde expansion is now supported.

## Solution

Either change the sample paths to absolute paths (like `/home/username/Documents/Meetings`) with a note that paths should be absolute, OR keep the tilde format and add a comment that tilde expansion is now supported. Consider using placeholder paths like `/absolute/path/to/collection`.

## Changes

- `sample-catalog.yml` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to clarify that `path` values must be absolute paths and that relative paths are not supported.
  * Updated example path configurations to demonstrate proper absolute path format instead of home-relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->