### PR TITLE
release: fix v1.3.3 changelog header format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.3](https://github.com/ambicuity/KINDX/compare/v1.3.2...v1.3.3) (2026-04-21)
+## [1.3.3] - 2026-04-21
 
 ### Added
 


### PR DESCRIPTION
Follow-up for release tag guard: normalize changelog header to required format .