### PR TITLE
fix(ci): force GitHub Packages registry during publish

### DIFF
--- a/.github/workflows/publish-from-tag.yml
+++ b/.github/workflows/publish-from-tag.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Publish to GitHub Packages (dry run)
         if: ${{ github.event.inputs.dry_run == 'true' && (github.event.inputs.publish_targets == 'both' || github.event.inputs.publish_targets == 'github') }}
-        run: npm publish --registry=https://npm.pkg.github.com --dry-run
+        run: npm pkg set publishConfig.registry=https://npm.pkg.github.com && npm publish --registry=https://npm.pkg.github.com --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -129,6 +129,6 @@ jobs:
 
       - name: Publish to GitHub Packages
         if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.publish_targets == 'both' || github.event.inputs.publish_targets == 'github') }}
-        run: npm publish --registry=https://npm.pkg.github.com
+        run: npm pkg set publishConfig.registry=https://npm.pkg.github.com && npm publish --registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Publish to GitHub Packages
         if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --registry=https://npm.pkg.github.com
+        run: npm pkg set publishConfig.registry=https://npm.pkg.github.com && npm publish --registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fix partial v1.3.3 release: GitHub Packages publish step was still targeting npmjs due publishConfig.registry. This forces npm.pkg.github.com during GH publish in both release workflows.