### PR TITLE
fix(engine): tier-2 cleanup and cross-cutting hygiene

### DIFF
--- a/engine/ai-usage.ts
+++ b/engine/ai-usage.ts
@@ -200,10 +200,14 @@ export function flushAiUsageQueue() {
   }
 }
 
-// Ensure flush on exit
+// Tier-2: flush usage queue on natural process exit only. The previous
+// implementation also installed SIGINT/SIGTERM handlers that called
+// process.exit(0) — overriding any other shutdown handler the host had
+// registered (CLI cursor cleanup, MCP daemon graceful drain, embedding
+// host's own teardown). Embedded consumers are now in control of the
+// signal lifecycle; only the on('exit') flush survives, which runs on
+// any exit path (including SIGINT/SIGTERM via the host's own handlers).
 process.on('exit', flushAiUsageQueue);
-process.on('SIGINT', () => { flushAiUsageQueue(); process.exit(0); });
-process.on('SIGTERM', () => { flushAiUsageQueue(); process.exit(0); });
 
 export function calculateCostUsd(model: string, inputTokens: number, outputTokens: number, cachedTokens: number = 0): number | null {
   const modelLower = model.toLowerCase();

--- a/engine/ir-metrics.ts
+++ b/engine/ir-metrics.ts
@@ -19,12 +19,15 @@
 export type RelevanceJudgments = Record<string, number>;
 
 /**
- * Normalize a document key (file path or name) for comparison.
- * Strips directory components and lowercases for fuzzy matching.
+ * Normalize a document key (file path) for relevance comparison.
+ *
+ * Tier-2: keep the full virtual path, not just the basename. Stripping to
+ * basename caused two unrelated `README.md` files in different directories
+ * to be treated as the same relevant document, inflating recall/precision
+ * scores in repos with repeated filenames.
  */
 function normalizeKey(name: string): string {
-  const basename = name.split("/").pop() ?? name;
-  return basename.toLowerCase().replace(/_/g, "-");
+  return name.toLowerCase().replace(/_/g, "-");
 }
 
 /**

--- a/engine/kindx.ts
+++ b/engine/kindx.ts
@@ -204,7 +204,8 @@ import {
   formatBytes,
   renderProgressBar,
   spinner,
-  Spinner
+  Spinner,
+  registerCursorCleanup,
 } from "./utils/ui.js";
 
 const isTTY = process.stderr.isTTY;
@@ -3441,6 +3442,12 @@ const isMain = argv1 === __filename
   || argv1?.endsWith("/kindx.js")
   || (argv1 != null && realpathSync(argv1) === __filename);
 if (isMain) {
+  // Tier-2: opt into the cursor-cleanup signal handlers ONLY when this file
+  // is invoked as the CLI entrypoint. Library/embedded callers (importing
+  // engine modules from another process) are no longer hijacked at module
+  // load time.
+  registerCursorCleanup();
+
   // Global error handlers — catch unhandled errors with user-friendly messages
   process.on('uncaughtException', (err: any) => {
     const code = err?.code;

--- a/engine/mcp-control-plane.ts
+++ b/engine/mcp-control-plane.ts
@@ -426,6 +426,14 @@ export class McpToolListCache {
 
   private enqueueDiskTask(task: () => Promise<void>): void {
     if (this.pendingTasks.length > 1000) {
+      // Tier-2: surface drops as a Prometheus counter, not just a one-shot
+      // warn-cache entry. Operators previously had no way to observe how
+      // often the queue was overflowing; cache writes silently disappeared
+      // and the cache could be perpetually stale with no signal.
+      try {
+        const { incCounter } = require("./utils/metrics.js");
+        incCounter("mcp_control_plane_task_dropped_total", 1);
+      } catch { /* metrics module load failure is itself a problem we don't want to compound */ }
       warnCache("queue_full", "global", "disk task queue limit reached, dropping task");
       return;
     }

--- a/engine/migrate.ts
+++ b/engine/migrate.ts
@@ -146,8 +146,14 @@ export async function migrateChroma(
         const contentHash = createHash("sha256").update(docText).digest("hex");
         const now = new Date().toISOString();
 
-        // Use the Chroma collection name as a prefix to avoid collisions if targetCollectionName is generic
-        const normalizedPath = `${row.chroma_collection || 'import'}/${path}`.replace(/[^a-zA-Z0-9/._-]/g, '_');
+        // Tier-2: preserve the original Unicode path. The previous regex
+        // `[^a-zA-Z0-9/._-] -> _` collapsed `a/b` and `a-b` to the same
+        // key, silently colliding non-ASCII filenames into one row. We use
+        // parameterized SQL throughout so non-ASCII path characters are
+        // safe to store verbatim. Drop only path-control chars and the
+        // SQLite-incompatible NUL.
+        const normalizedPath = `${row.chroma_collection || 'import'}/${path}`
+          .replace(/[\x00-\x1F\x7F]/g, "_");
 
         // Tier-0-12: idempotency. If we crashed mid-run last time and the
         // user re-invokes the migration, the previous code threw on the

--- a/engine/protocol.ts
+++ b/engine/protocol.ts
@@ -2282,7 +2282,17 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
           logger.info(`Session ${sid} cleaned up`);
         }
       }
-      void disposeSensitiveContexts().catch(() => {});
+      // Tier-2: surface a sensitive-context cleanup failure as a quietWarn
+      // counter rather than silently dropping it. A failure here means
+      // session-scoped secrets may still be in memory.
+      void disposeSensitiveContexts().catch((err) => {
+        try {
+          const { quietWarn } = require("./utils/quiet-warn.js");
+          quietWarn("session.dispose_sensitive_contexts_failed", {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        } catch { /* metrics module load failure shouldn't crash teardown */ }
+      });
     };
 
     return transport;

--- a/engine/remote-llm.ts
+++ b/engine/remote-llm.ts
@@ -308,8 +308,10 @@ export class RemoteLLM implements LLM {
 
   async generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null> {
     const model = options?.model || this.generateModel;
-    const max_tokens = options?.maxTokens || 150;
-    const temperature = options?.temperature || 0.7;
+    // Tier-2: ?? not || so callers explicitly passing maxTokens=0 / temperature=0
+    // (greedy decoding) aren't silently overridden by the defaults.
+    const max_tokens = options?.maxTokens ?? 150;
+    const temperature = options?.temperature ?? 0.7;
 
     try {
       const res = await fetchWithTimeout(`${getBaseUrl()}/chat/completions`, {

--- a/engine/renderer.ts
+++ b/engine/renderer.ts
@@ -155,9 +155,36 @@ export function searchResultsToCsv(
  */
 export function searchResultsToFiles(results: SearchResult[]): string {
   return results.map(row => {
-    const ctx = row.context ? `,"${row.context.replace(/"/g, '""')}"` : "";
-    return `#${row.docid},${row.score.toFixed(2)},${row.displayPath}${ctx}`;
+    const ctx = row.context ? `,${csvField(row.context)}` : "";
+    // Tier-2: csvField on displayPath as well — POSIX paths can contain
+    // commas, double-quotes, and (rarely) newlines. Without escaping, a
+    // path with a comma broke the column layout for every downstream parser.
+    return `#${row.docid},${row.score.toFixed(2)},${csvField(row.displayPath)}${ctx}`;
   }).join("\n");
+}
+
+/**
+ * RFC 4180 CSV-field encoding: quote when the field contains a comma,
+ * double-quote, CR, or LF; double internal quotes.
+ */
+function csvField(raw: string): string {
+  const needsQuote = /[",\r\n]/.test(raw);
+  if (!needsQuote) return raw;
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Pick a markdown code fence longer than the longest run of consecutive
+ * backticks in `body`, so the body cannot terminate its wrapper. CommonMark
+ * requires the closing fence be at least as long as the opening fence.
+ */
+function makeMarkdownFence(body: string): string {
+  let longest = 2; // we always need at least ``` (3) so start at 2
+  const matches = body.match(/`+/g);
+  if (matches) {
+    for (const m of matches) longest = Math.max(longest, m.length);
+  }
+  return "`".repeat(longest + 1);
 }
 
 /**
@@ -258,9 +285,9 @@ export function documentsToCsv(results: MultiGetFile[]): string {
  */
 export function documentsToFiles(results: MultiGetFile[]): string {
   return results.map(r => {
-    const ctx = r.context ? `,"${r.context.replace(/"/g, '""')}"` : "";
+    const ctx = r.context ? `,${csvField(r.context)}` : "";
     const status = r.skipped ? ",[SKIPPED]" : "";
-    return `${r.displayPath}${ctx}${status}`;
+    return `${csvField(r.displayPath)}${ctx}${status}`;
   }).join("\n");
 }
 
@@ -275,7 +302,12 @@ export function documentsToMarkdown(results: MultiGetFile[]): string {
     if (r.skipped) {
       md += `> ${r.skipReason}\n`;
     } else {
-      md += "```\n" + r.body + "\n```\n";
+      // Tier-2: count consecutive backticks in the body and use a longer
+      // fence so the body cannot escape its code block. A document
+      // containing ``` would otherwise terminate the wrapper early and
+      // bleed raw markdown into the output, breaking downstream rendering.
+      const fence = makeMarkdownFence(r.body || "");
+      md += `${fence}\n${r.body}\n${fence}\n`;
     }
     return md;
   }).join("\n");

--- a/engine/repository.ts
+++ b/engine/repository.ts
@@ -1538,9 +1538,13 @@ export function deactivateDocument(db: Database, collectionName: string, path: s
     .run(collectionName, path);
     
   if (res.changes > 0) {
-    // Schedule asynchronous GC for unreferenced vectors to prevent index bloat
+    // Schedule asynchronous GC for unreferenced vectors to prevent index bloat.
+    // Tier-2: replace silent catch with quietWarn so cleanup failures are
+    // visible via /metrics (was a black hole — the cleanup may run after
+    // store.close() and throw on a closed handle).
     setTimeout(() => {
-      try { cleanupOrphanedVectors(db); } catch {}
+      try { cleanupOrphanedVectors(db); }
+      catch (e) { quietWarn("repository.cleanup_orphaned_vectors_failed", { err: errString(e) }); }
     }, 0);
   }
 }

--- a/engine/tool-registry.ts
+++ b/engine/tool-registry.ts
@@ -183,9 +183,13 @@ export function registerKindxTool<TInput, TOutput extends Record<string, unknown
       const typedInput = input as TInput;
       const ctx = getContext();
 
-      // Log query if it looks like a search operation
+      // Log query if it looks like a search operation. Tier-2: cap the
+      // logged query to 1024 chars so a 10 MiB user-supplied query string
+      // doesn't sit in the in-memory session log forever.
       if (ctx.session && typeof (input as any).query === "string") {
-        ctx.session.logQuery((input as any).query as string);
+        const raw = (input as any).query as string;
+        const capped = raw.length > 1024 ? raw.slice(0, 1024) + "…" : raw;
+        ctx.session.logQuery(capped);
       }
 
       try {

--- a/engine/utils/logger.ts
+++ b/engine/utils/logger.ts
@@ -39,21 +39,47 @@ export function configureLogger(options: { level?: string; format?: string }): v
   }
 }
 
+/**
+ * Tier-2: strip newlines, carriage returns, and ANSI escape sequences from
+ * a log message before emitting. Without sanitization, an attacker-controlled
+ * value (file path, query string, header) embedded in a log line could
+ * inject forged log entries or spoof control codes (`\n[ERROR] system
+ * breached`). Applies to both `msg` and string values inside `meta`.
+ */
+function sanitizeLogValue(v: unknown): unknown {
+  if (typeof v === "string") {
+    return v
+      .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "") // CSI escapes
+      .replace(/\x1b\][^\x07]*\x07/g, "")      // OSC escapes
+      .replace(/[\r\n]+/g, " ⏎ ");             // collapse newlines
+  }
+  return v;
+}
+
 export const logger = {
   log(level: LogLevel, msg: string, meta?: Record<string, unknown>) {
     if ((LOG_LEVELS[level] ?? LOG_LEVELS['INFO']) < currentLevelWeight) return;
+
+    const safeMsg = sanitizeLogValue(msg) as string;
+    let safeMeta: Record<string, unknown> | undefined;
+    if (meta) {
+      safeMeta = {};
+      for (const [k, v] of Object.entries(meta)) {
+        safeMeta[k] = sanitizeLogValue(v);
+      }
+    }
 
     if (logFormat === 'json') {
       const payload = {
         timestamp: new Date().toISOString(),
         level,
-        msg,
-        ...meta
+        msg: safeMsg,
+        ...safeMeta,
       };
       process.stderr.write(JSON.stringify(payload) + '\n');
     } else {
-      const metaStr = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
-      process.stderr.write(`[${new Date().toISOString()}] [${level}] ${msg}${metaStr}\n`);
+      const metaStr = safeMeta && Object.keys(safeMeta).length > 0 ? ` ${JSON.stringify(safeMeta)}` : '';
+      process.stderr.write(`[${new Date().toISOString()}] [${level}] ${safeMsg}${metaStr}\n`);
     }
   },
 

--- a/engine/utils/metrics.ts
+++ b/engine/utils/metrics.ts
@@ -23,9 +23,33 @@ function key(name: string, labels?: Record<string, string | number | boolean>): 
   return `${name}${makeLabels(labels)}`;
 }
 
+// Tier-2: cap the number of distinct (name+labels) tuples we will track.
+// Without this, a counter labelled by a high-cardinality dimension (file
+// path, query string, IP) could grow without bound across long-lived
+// daemons. Overflow is folded into a `__overflow__` label so the data is
+// not lost — just bucketed.
+const COUNTER_LABEL_CARDINALITY_CAP = (() => {
+  const raw = parseInt(process.env.KINDX_METRICS_LABEL_CAP || "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 5000;
+})();
+
+function overflowKey(name: string): string {
+  return `${name}{__overflow__="1"}`;
+}
+
 export function incCounter(name: string, value = 1, labels?: Record<string, string | number | boolean>): void {
   const k = key(name, labels);
-  counters.set(k, (counters.get(k) || 0) + value);
+  if (counters.has(k)) {
+    counters.set(k, (counters.get(k) || 0) + value);
+    return;
+  }
+  // New tuple — guard against cardinality explosion.
+  if (counters.size >= COUNTER_LABEL_CARDINALITY_CAP) {
+    const ok = overflowKey(name);
+    counters.set(ok, (counters.get(ok) || 0) + value);
+    return;
+  }
+  counters.set(k, value);
 }
 
 export function observeHistogram(

--- a/engine/utils/ui.ts
+++ b/engine/utils/ui.ts
@@ -19,17 +19,23 @@ export const cursor = {
   clearLine() { process.stderr.write('\r\x1b[K'); },
 };
 
-// Ensure cursor is restored on exit
+// Tier-2: cursor cleanup is opt-in via registerCursorCleanup() rather than
+// installed at import time. The previous implementation installed SIGINT /
+// SIGTERM handlers as a side effect of importing this module, AND called
+// process.exit() inside them — which (a) silently overrides any host
+// program's own shutdown handlers when this module is imported, and (b)
+// makes the engine unembeddable. The CLI entrypoint (`bin/kindx`) is the
+// only caller that should opt in.
 let _signalsRegistered = false;
 export function registerCursorCleanup(): void {
   if (typeof process === "undefined" || _signalsRegistered) return;
-  const isCli = process.title === "node" && !process.env.VITEST && !process.env.NODE_ENV?.includes("test");
-  if (!isCli) return;
   _signalsRegistered = true;
+  // Once registered, we own the SIGINT/SIGTERM exit code — that's the
+  // contract callers (the CLI entrypoint) opt into. Library callers
+  // simply never call this function.
   process.on('SIGINT', () => { cursor.show(); process.exit(130); });
   process.on('SIGTERM', () => { cursor.show(); process.exit(143); });
 }
-registerCursorCleanup();
 
 // Terminal progress bar using OSC 9;4 escape sequence (TTY only)
 const isTTY = process.stderr.isTTY;


### PR DESCRIPTION
## Summary

PR3 of a 3-PR engine hardening pass. Lands the highest-impact Tier-2 audit findings + the cross-cutting hygiene work that makes the engine safely embeddable.

### Process hygiene — engine becomes safely embeddable
- **`utils/ui.ts:24`** — `registerCursorCleanup()` is now opt-in. The previous auto-call at module import installed SIGINT/SIGTERM handlers that called `process.exit()`, silently overriding any host program's own shutdown. Library/embedded callers no longer have their signal lifecycle hijacked. The CLI entrypoint (`kindx.ts:isMain`) calls it explicitly.
- **`ai-usage.ts:204`** — removed the SIGINT/SIGTERM handlers that called `process.exit(0)` on signal. Same overriding-host-shutdown problem. Only the `on('exit')` flush survives, which fires on any exit path.

### Default-value bugs
- **`remote-llm.ts:311`** — `||` → `??` for `maxTokens` and `temperature` so callers passing `0` (greedy decoding) aren't silently overridden.

### Path / string handling
- **`renderer.ts:158,272`** — both file-format renderers CSV-escape `displayPath` via a shared `csvField()` helper.
- **`renderer.ts:283`** — markdown body wrapping picks a fence longer than the longest backtick run in the body so a body containing ` ``` ` can't terminate the wrapper early.
- **`utils/logger.ts:43`** — strips ANSI escapes + collapses newlines in both `msg` and `meta` string values before emit. Stops log injection via attacker-controlled values.
- **`utils/metrics.ts:26`** — counter labels capped at `KINDX_METRICS_LABEL_CAP` (default 5000) tuples per process; overflow folds to `__overflow__`. Defends against unbounded label cardinality.
- **`migrate.ts:134`** — Chroma-import path normalization preserves Unicode (only NUL + control chars stripped). Prevents collision of distinct i18n filenames into the same key.

### Unbounded growth + visibility
- **`mcp-control-plane.ts:428`** — disk-task queue overflow now also increments `mcp_control_plane_task_dropped_total` so operators can see the drops via `/metrics`.
- **`tool-registry.ts:188`** — query log entry truncated at 1024 chars so a 10 MiB query string doesn't camp in the in-memory session log.
- **`repository.ts:1543`** — orphaned-vector cleanup empty catch → `quietWarn` so failures (e.g. cleanup running after `store.close()`) are observable via `/metrics`.
- **`protocol.ts:2285`** — `disposeSensitiveContexts` empty catch → `quietWarn` so a failure (session secrets potentially still in memory) is visible.

### Other notable
- **`ir-metrics.ts:25`** — `normalizeKey` uses the full virtual path, not basename. Stops repos with many `README.md` files from over-counting relevance.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — **970 passing**
- [x] All previously-touched specs green

## Closing the audit

This PR completes the 3-PR plan from the original 5-agent audit (`engine/`, ~24k LOC, 165 findings):

- **PR1 #130** — 12 Tier-0 stop-the-line + 7 foundation utilities + 108 new tests
- **PR2 #131** — ~30 Tier-1 high-severity (concurrency, network, correctness, perf, security)
- **PR3 (this)** — Tier-2 cleanup + cross-cutting

Combined: build clean, 970 tests pass (was 851 — +119 regression tests added), P0/P1/P2 launch gates green, plus runtime defenses against:
- vector wipe / data loss on every store open
- shell injection / RCE in `migrate openclaw`
- plaintext backup leak after rekey
- weak token hashing + timing oracle
- HTTP body OOM + slowloris
- pool starvation + abort-listener leaks
- prompt injection via untrusted markdown context
- path traversal in virtual paths + link extractor
- log injection + label cardinality explosion
- library `process.exit` and signal hijack making the engine unembeddable

🤖 Generated with [Claude Code](https://claude.com/claude-code)