### PR TITLE
chore: sync marketplace.json to v1.3.5

### DIFF
--- a/.agent-plugin/marketplace.json
+++ b/.agent-plugin/marketplace.json
@@ -9,7 +9,7 @@
 			"name": "kindx",
 			"source": "./",
 			"description": "Local-first hybrid CLI/MCP search engine for personal knowledge bases and agentic workflows, combining BM25, vector retrieval, and LLM reranking locally via node-llama-cpp/GGUF.",
-			"version": "1.3.4",
+			"version": "1.3.5",
 			"author": {
 				"name": "ambicuity",
 				"email": "contact@riteshrana.engineer"


### PR DESCRIPTION
Sync `.agent-plugin/marketplace.json` version to v1.3.5 to match `package.json`.

Unblocks the release-please publish job's "Guardrail (marketplace metadata in sync)" step that just failed on the v1.3.5 release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.3.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->