### PR TITLE
chore: add Keep-a-Changelog format header for v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2026-05-09
+
+See full changelog at https://github.com/ambicuity/KINDX/compare/v1.3.4...v1.3.5
+
 ## [1.3.5](https://github.com/ambicuity/KINDX/compare/v1.3.4...v1.3.5) (2026-05-09)
 
 


### PR DESCRIPTION
The pre-push hook (`tooling/pre-push`) validates CHANGELOG.md contains a `## [VERSION] - YYYY-MM-DD` entry before any v* tag push. release-please uses its own format `## [VERSION](url) (date)` which the hook doesn't recognize. Add the Keep-a-Changelog header above the release-please entry so future tag pushes (including the imminent v1.3.5 re-tag to include the marketplace.json fix) succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)