### PR TITLE
chore: include README.md and AGENT.md in published npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "dist/",
     "capabilities/kindx/",
     "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md",
+    "AGENT.md"
   ],
   "scripts": {
     "prepare": "[ -d .git ] && ./tooling/install-hooks.sh || true",


### PR DESCRIPTION
Add `README.md` and `AGENT.md` to `package.json` `files` so the npm tarball ships them.

The package-level `.readme` field on npmjs.com is currently correct (matches GitHub README) because npm preserves the cached registry-level readme across publishes when a new tarball lacks one. But the actual tarball for `@ambicuity/kindx@1.3.5` does NOT contain README.md — see `npm pack --dry-run` against the previous package.json `files` whitelist which only listed `bin/, dist/, capabilities/kindx/, LICENSE, CHANGELOG.md`.

Future tarballs will include both files explicitly, removing the dependency on the registry's cached readme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)