### PR TITLE
docs: declare Python integration as thin-adapter (W2)

### DIFF
--- a/PYTHON.md
+++ b/PYTHON.md
@@ -1,0 +1,37 @@
+# Python Integration
+
+**Status:** Thin adapter. Not a supported Python product tier.
+**Decision date:** 2026-05-20
+**Spec reference:** docs/superpowers/specs/2026-05-20-kindx-strategic-refactor-program-design.md §6
+
+## What ships
+
+`python/kindx-langchain/` is a single-file LangChain retriever wrapper around the KINDX HTTP API. It exists for convenience in Python notebooks and small scripts. It is not a stable API surface.
+
+## What does not ship
+
+- No sync/async client beyond what the wrapper exposes.
+- No retry/backoff, streaming `/query/stream` support, or structured-query helpers in this package.
+- No PyPI release cadence beyond unit-test passing.
+
+## How to integrate from Python
+
+For anything beyond toy use, call the KINDX HTTP API directly:
+
+- `POST /query` for structured retrieval (see root README, HTTP Endpoints).
+- `POST /query/stream` for streaming results.
+- Use any HTTP client (`httpx`, `requests`); request and response shapes are documented in `@ambicuity/kindx-schemas`.
+
+## Why we chose this shape
+
+The cost of maintaining a supported Python tier (typed sync+async client, streaming, PyPI release process, examples for multiple frameworks) is several weeks of focused work and a permanent maintenance commitment. Demand has not been measured. Until that data exists, the honest framing is "thin adapter, call HTTP directly for production."
+
+If demand emerges, this decision is reversible by following spec §6 Option B (separate spec required).
+
+## Reversal criteria
+
+This decision should be re-opened when any of the following is true:
+
+- Sustained external usage of the `kindx-langchain` PyPI package above an agreed threshold.
+- Concrete user requests for Python features beyond the wrapper's surface.
+- A KINDX-internal need for a Python integration tier.

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ npm run test -w @ambicuity/kindx-client
 
 ## Python Integration
 
-`python/kindx-langchain` contains an installable Python package named `kindx-langchain`.
+`python/kindx-langchain` is a thin LangChain retriever wrapper around the KINDX HTTP API. It is not a supported Python product tier — see [PYTHON.md](./PYTHON.md) for the policy and reversal criteria. For production integrations from Python, call the HTTP API directly.
 
 ```bash
 python3 -m unittest discover -s python/kindx-langchain/tests -v

--- a/python/kindx-langchain/README.md
+++ b/python/kindx-langchain/README.md
@@ -1,5 +1,9 @@
 # kindx-langchain
 
+> **Status: thin adapter.** This package is a LangChain retriever wrapper around the KINDX HTTP API. It is not a full Python product. For production integrations call the HTTP API directly. See [PYTHON.md](../../PYTHON.md) at the repo root for the full decision.
+
+---
+
 `kindx-langchain` provides `KindxRetriever`, a lightweight retriever that queries a running KINDX HTTP/MCP server and returns LangChain-style documents.
 
 ```python


### PR DESCRIPTION
## Summary
Implements **W2** from the strategic refactor program: keep \`python/kindx-langchain\` as a thin LangChain retriever wrapper, label its scope honestly, no engineering investment.

- Adds \`PYTHON.md\` recording the decision, rationale, and reversal criteria
- Adds a "thin adapter" banner to \`python/kindx-langchain/README.md\`
- Updates root README's Python Integration section to point at \`PYTHON.md\`

No code changes. \`npm run test:python\` still green.

## Why
The README previously framed \`python/kindx-langchain\` as a peer feature alongside the TypeScript schemas/client packages, but the surface area (one test file, single retriever class) doesn't support that framing. Correcting it now removes a credibility risk and creates explicit reversal criteria for if Python adoption emerges later.

## Test plan
- [ ] CI green
- [ ] Reviewer reads \`PYTHON.md\` and confirms the policy + reversal criteria are clear
- [ ] Reviewer confirms the banner is the first content line of the Python README

Spec: \`docs/superpowers/specs/2026-05-20-kindx-strategic-refactor-program-design.md\` §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)