### PR TITLE
chore: bench:quality skips gracefully when corpus is missing

### DIFF
--- a/tooling/benchmarks/README.md
+++ b/tooling/benchmarks/README.md
@@ -1,0 +1,55 @@
+# Benchmark fixtures
+
+This directory holds the **judgment manifests** (small, in-repo) and expects two **corpus directories** (large, NOT in repo) to be populated locally for the `bench:quality` track.
+
+## What's in the repo
+
+```
+tooling/benchmarks/
+├── runner.ts                 # Dispatcher (npm run bench:*)
+├── section6_bench.ts         # Quality benchmark (hit@3, hit@5, MRR by difficulty)
+├── section6-results.schema.json
+└── judgments/
+    ├── msmarco.v1.json       # 24 graded queries against the MS MARCO corpus
+    └── dbpedia.v1.json       # 24 graded queries against the DBpedia corpus
+```
+
+## What's NOT in the repo
+
+```
+tooling/benchmarks/
+├── test_corpus_msmarco/      # ~1000 markdown docs from MS MARCO passage set
+└── test_corpus_dbpedia/      # ~1000 markdown docs from DBpedia long abstracts
+```
+
+The corpora are excluded because they would add tens to hundreds of MB to every clone and most contributors will never run the quality bench locally.
+
+## How `section6_bench.ts` finds the corpus
+
+Each judgment manifest declares the corpus path in its `source_corpus` field:
+
+```json
+{
+  "schema": "kindx-benchmark-judgments-v1",
+  "dataset": "MS MARCO 1000",
+  "source_corpus": "tooling/benchmarks/test_corpus_msmarco",
+  "queries": [...]
+}
+```
+
+At runtime, `section6_bench.ts` resolves that path relative to the repo root, copies it into a temporary index location, and runs the benchmark. If the directory is missing, the run **skips that dataset with a clear message** (since 2026-05-20) instead of crashing.
+
+## How to populate a corpus
+
+Each markdown file in the corpus must be named to match the relevance entries in the judgment manifest. For example, `msmarco.v1.json` references `doc_0000.md` through `doc_0999.md`. Files outside that name range are ignored by the bench but still indexed.
+
+The simplest path is to assemble a corpus from the original MS MARCO / DBpedia data dumps, converting each passage / abstract into a markdown file numbered to match the judgment manifest. The exact reproduction recipe is a future workstream — for now this README documents the format and the bench skips gracefully when the corpus is absent.
+
+## What `npm run bench:quality` does today
+
+- ✅ Dispatches correctly to `section6_bench.ts` via `tooling/benchmarks/runner.ts`
+- ✅ Skips datasets whose corpus directory is missing, with a clear message
+- ⚠️  Exits 2 under `--enforce` if *all* datasets were skipped (no usable corpus)
+- ⚠️  Real quality numbers require a populated corpus
+
+This is the honest framing: the quality gate is **operational** but requires fixtures that are intentionally not in the repo. Provide the corpora and `bench:quality` will produce real numbers.

--- a/tooling/benchmarks/section6_bench.ts
+++ b/tooling/benchmarks/section6_bench.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { cpSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, basename } from "node:path";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
@@ -748,8 +748,41 @@ async function main(): Promise<void> {
   ];
 
   const datasets: DatasetResult[] = [];
+  const skipped: { manifest: string; reason: string }[] = [];
   for (const m of manifests) {
+    // Pre-flight: if the source corpus directory does not exist on disk,
+    // skip the dataset with a clear message instead of crashing in cpSync.
+    // The corpora are large fixtures (MS MARCO / DBpedia) that are not
+    // bundled with the repo — see tooling/benchmarks/README.md.
+    try {
+      const manifest = readJson<JudgmentManifest>(m);
+      const corpusDir = resolve(ROOT, manifest.source_corpus);
+      if (!existsSync(corpusDir)) {
+        const msg = `corpus not found at ${manifest.source_corpus}`;
+        console.warn(`[section6] SKIP ${basename(m)}: ${msg}`);
+        skipped.push({ manifest: basename(m), reason: msg });
+        continue;
+      }
+    } catch (err) {
+      const msg = `failed to read manifest: ${err}`;
+      console.warn(`[section6] SKIP ${basename(m)}: ${msg}`);
+      skipped.push({ manifest: basename(m), reason: msg });
+      continue;
+    }
     datasets.push(await benchmarkDataset(m));
+  }
+
+  if (datasets.length === 0) {
+    console.error(
+      `[section6] No datasets had a usable corpus. ${skipped.length} skipped:\n` +
+      skipped.map((s) => `  - ${s.manifest}: ${s.reason}`).join("\n") +
+      `\n\nSee tooling/benchmarks/README.md for how to populate the corpora.`
+    );
+    // Non-enforced: still write a report listing skips so CI artifacts are useful.
+    // Enforced: caller (runner.ts with --enforce) gets a non-zero exit.
+    if (process.env.KINDX_BENCH_ENFORCE === "1") {
+      process.exit(2);
+    }
   }
 
   const report: Section6Results = {


### PR DESCRIPTION
## Summary
Completes the bench infrastructure restoration from #151. Previously \`npm run bench:quality\` crashed with a \`cpSync\` ENOENT stack trace when the MS MARCO / DBpedia corpus directories weren't on disk. Now it skips gracefully with a clear message.

## Before

\`\`\`
$ npm run bench:quality
node:fs:1234
    throw err;
Error: ENOENT: no such file or directory, stat 'tooling/benchmarks/test_corpus_msmarco'
    ...
\`\`\`

## After

\`\`\`
$ npm run bench:quality
[runner] ▶ bm25-quality  (tooling/benchmarks/section6_bench.ts)
[section6] SKIP msmarco.v1.json: corpus not found at tooling/benchmarks/test_corpus_msmarco
[section6] SKIP dbpedia.v1.json: corpus not found at tooling/benchmarks/test_corpus_dbpedia
[section6] No datasets had a usable corpus. 2 skipped:
  - msmarco.v1.json: corpus not found at tooling/benchmarks/test_corpus_msmarco
  - dbpedia.v1.json: corpus not found at tooling/benchmarks/test_corpus_dbpedia

See tooling/benchmarks/README.md for how to populate the corpora.
[runner] ✗ bm25-quality exited 2 in 2.0s
\`\`\`

## Changes
- \`tooling/benchmarks/section6_bench.ts\` — pre-flight check before \`cpSync\`; skip manifest if corpus missing; exit 2 under \`--enforce\` if all datasets skip
- \`tooling/benchmarks/README.md\` (new) — documents fixture layout, what's in/out of the repo, expected behavior

## Why this matters
With this change, all three working bench tracks have honest failure modes:

| Track | Behavior |
|---|---|
| \`bench:regressions\` | ✅ Produces real numbers (works as-is) |
| \`bench:latency\` | ✅ Reports threshold violations when no daemon (silent-fail fixed in #151) |
| \`bench:quality\` | ✅ Skips gracefully when corpora missing; runs real benchmark when corpora present |

The quality gate is now **operational** — running it gives an actionable result regardless of whether the fixture corpora are populated. Real numbers require populating the corpora per \`tooling/benchmarks/README.md\`.

## Test plan
- [ ] CI green
- [ ] \`npm run bench:quality\` produces the SKIP messages shown above (the test_corpus directories should NOT be in the repo)
- [ ] \`npm test\` still passes (963/963)

🤖 Generated with [Claude Code](https://claude.com/claude-code)