### PR TITLE
chore(config): drop unused baseUrl from kindx-client tsconfig

### DIFF
--- a/packages/kindx-client/tsconfig.json
+++ b/packages/kindx-client/tsconfig.json
@@ -4,7 +4,6 @@
     "rootDir": ".",
     "outDir": "dist",
     "declaration": true,
-    "baseUrl": ".",
     "paths": {
       "@ambicuity/kindx-schemas": ["../kindx-schemas/dist/src/index.d.ts"]
     }


### PR DESCRIPTION
## Summary
- Removes `baseUrl: "."` from `packages/kindx-client/tsconfig.json`. It's deprecated in TypeScript 6.0 and stops functioning in 7.0.
- Since TS 5.0, `paths` resolves relative to the tsconfig file when `baseUrl` is omitted, so the existing `@ambicuity/kindx-schemas` mapping continues to work.
- Unblocks #119 (TypeScript 5→6 dependabot bump).

## Test plan
- [x] `npm run build -w @ambicuity/kindx-client` succeeds
- [x] `npm run test -w @ambicuity/kindx-client` passes (4/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted project build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ambicuity/KINDX/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->